### PR TITLE
feat/pla 18 jsexport support

### DIFF
--- a/all/src/commonMain/kotlin/work/socialhub/planetlink/define/ServiceType.kt
+++ b/all/src/commonMain/kotlin/work/socialhub/planetlink/define/ServiceType.kt
@@ -1,9 +1,12 @@
 package work.socialhub.planetlink.define
 
+import kotlin.js.JsExport
+
 /**
  * 対応 SNS
  * SNS List
  */
+@JsExport
 enum class ServiceType {
     Twitter,
     Mastodon,

--- a/all/src/commonMain/kotlin/work/socialhub/planetlink/model/ServiceEx.kt
+++ b/all/src/commonMain/kotlin/work/socialhub/planetlink/model/ServiceEx.kt
@@ -1,28 +1,37 @@
 package work.socialhub.planetlink.model
 
+import kotlin.js.JsExport
+
+@JsExport
 object ServiceEx {
 
     /** Is Twitter Account ?  */
+    @JsExport.Ignore
     val Service.isTwitter: Boolean
         get() = ("twitter" == type.lowercase())
 
     /** Is Slack Account ?  */
+    @JsExport.Ignore
     val Service.isSlack: Boolean
         get() = ("slack" == type.lowercase())
 
     /** Is Facebook Account ?  */
+    @JsExport.Ignore
     val Service.isFacebook: Boolean
         get() = ("facebook" == type.lowercase())
 
     /** Is Tumblr Account ?  */
+    @JsExport.Ignore
     val Service.isTumblr: Boolean
         get() = ("tumblr" == type.lowercase())
 
     /** Is Nostr Account ?  */
+    @JsExport.Ignore
     val Service.isNostr: Boolean
         get() = ("nostr" == type.lowercase())
 
     /** Is Matrix Account ?  */
+    @JsExport.Ignore
     val Service.isMatrix: Boolean
         get() = ("matrix" == type.lowercase())
 }

--- a/all/src/commonMain/kotlin/work/socialhub/planetlink/refer/Reference.kt
+++ b/all/src/commonMain/kotlin/work/socialhub/planetlink/refer/Reference.kt
@@ -5,7 +5,9 @@ import work.socialhub.planetlink.bluesky.expand.PlanetLinkEx as PlanetLinkExBlue
 import work.socialhub.planetlink.misskey.expand.PlanetLinkEx as PlanetLinkExMisskey
 import work.socialhub.planetlink.mastodon.expand.PlanetLinkEx as PlanetLinkExMastodon
 import work.socialhub.planetlink.matrix.expand.PlanetLinkEx as PlanetLinkExMatrix
+import kotlin.js.JsExport
 
+@JsExport
 object Reference {
 
     val references = listOf(

--- a/bluesky/src/commonMain/kotlin/work/socialhub/planetlink/bluesky/define/BlueskyNotificationType.kt
+++ b/bluesky/src/commonMain/kotlin/work/socialhub/planetlink/bluesky/define/BlueskyNotificationType.kt
@@ -1,10 +1,12 @@
 package work.socialhub.planetlink.bluesky.define
 
 import work.socialhub.planetlink.define.NotificationActionType
+import kotlin.js.JsExport
 
 /**
  * like, repost, follow, mention, reply, quote
  */
+@JsExport
 enum class BlueskyNotificationType(
     val action: NotificationActionType,
     val code: String

--- a/bluesky/src/commonMain/kotlin/work/socialhub/planetlink/bluesky/define/BlueskyReactionType.kt
+++ b/bluesky/src/commonMain/kotlin/work/socialhub/planetlink/bluesky/define/BlueskyReactionType.kt
@@ -1,9 +1,12 @@
 package work.socialhub.planetlink.bluesky.define
 
+import kotlin.js.JsExport
+
 /**
  * Bluesky Reaction Type
  * (Action code with alias)
  */
+@JsExport
 enum class BlueskyReactionType(
     vararg codes: String
 ) {

--- a/bluesky/src/commonMain/kotlin/work/socialhub/planetlink/bluesky/expand/PlanetLinkEx.kt
+++ b/bluesky/src/commonMain/kotlin/work/socialhub/planetlink/bluesky/expand/PlanetLinkEx.kt
@@ -2,7 +2,9 @@ package work.socialhub.planetlink.bluesky.expand
 
 import work.socialhub.planetlink.PlanetLink
 import work.socialhub.planetlink.bluesky.action.BlueskyAuth
+import kotlin.js.JsExport
 
+@JsExport
 object PlanetLinkEx {
 
     /**

--- a/bluesky/src/commonMain/kotlin/work/socialhub/planetlink/bluesky/expand/ServiceEx.kt
+++ b/bluesky/src/commonMain/kotlin/work/socialhub/planetlink/bluesky/expand/ServiceEx.kt
@@ -1,10 +1,13 @@
 package work.socialhub.planetlink.bluesky.expand
 
 import work.socialhub.planetlink.model.Service
+import kotlin.js.JsExport
 
+@JsExport
 object ServiceEx {
 
     /** Is Bluesky Account ?  */
+    @JsExport.Ignore
     val Service.isBluesky: Boolean
         get() = ("bluesky" == type.lowercase())
 }

--- a/bluesky/src/commonMain/kotlin/work/socialhub/planetlink/bluesky/model/BlueskyChannel.kt
+++ b/bluesky/src/commonMain/kotlin/work/socialhub/planetlink/bluesky/model/BlueskyChannel.kt
@@ -3,11 +3,13 @@ package work.socialhub.planetlink.bluesky.model
 import work.socialhub.planetlink.model.Channel
 import work.socialhub.planetlink.model.Service
 import work.socialhub.planetlink.model.User
+import kotlin.js.JsExport
 
 /**
  * Bluesky Channel Model
  * Bluesky のチャンネル情報
  */
+@JsExport
 class BlueskyChannel(
     service: Service
 ) : Channel(service) {

--- a/bluesky/src/commonMain/kotlin/work/socialhub/planetlink/bluesky/model/BlueskyComment.kt
+++ b/bluesky/src/commonMain/kotlin/work/socialhub/planetlink/bluesky/model/BlueskyComment.kt
@@ -7,11 +7,13 @@ import work.socialhub.planetlink.model.Identify
 import work.socialhub.planetlink.model.Reaction
 import work.socialhub.planetlink.model.Service
 import work.socialhub.planetlink.model.request.CommentForm
+import kotlin.js.JsExport
 
 /**
  * Bluesky Comment Model
  * Bluesky のコメント情報
  */
+@JsExport
 class BlueskyComment(
     service: Service
 ) : MicroBlogComment(service) {

--- a/bluesky/src/commonMain/kotlin/work/socialhub/planetlink/bluesky/model/BlueskyPaging.kt
+++ b/bluesky/src/commonMain/kotlin/work/socialhub/planetlink/bluesky/model/BlueskyPaging.kt
@@ -2,7 +2,9 @@ package work.socialhub.planetlink.bluesky.model
 
 import work.socialhub.planetlink.model.Identify
 import work.socialhub.planetlink.model.Paging
+import kotlin.js.JsExport
 
+@JsExport
 class BlueskyPaging(
     count: Int? = null,
 ) : Paging(count) {

--- a/bluesky/src/commonMain/kotlin/work/socialhub/planetlink/bluesky/model/BlueskyUser.kt
+++ b/bluesky/src/commonMain/kotlin/work/socialhub/planetlink/bluesky/model/BlueskyUser.kt
@@ -2,11 +2,13 @@ package work.socialhub.planetlink.bluesky.model
 
 import work.socialhub.planetlink.micro.MicroBlogUser
 import work.socialhub.planetlink.model.Service
+import kotlin.js.JsExport
 
 /**
  * Bluesky User Model
  * Bluesky のユーザー情報
  */
+@JsExport
 class BlueskyUser(
     service: Service
 ) : MicroBlogUser(service) {

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/PlanetLink.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/PlanetLink.kt
@@ -1,5 +1,8 @@
 package work.socialhub.planetlink
 
+import kotlin.js.JsExport
+
+@JsExport
 class PlanetLink {
     companion object
 }

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/action/AccountAction.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/action/AccountAction.kt
@@ -6,11 +6,13 @@ import work.socialhub.planetlink.define.emoji.EmojiVariationType
 import work.socialhub.planetlink.model.*
 import work.socialhub.planetlink.model.error.NotImplementedException
 import work.socialhub.planetlink.model.request.CommentForm
+import kotlin.js.JsExport
 
 /**
  * Account Actions
  * (全てのアクションを定義)
  */
+@JsExport
 interface AccountAction {
 
     // ============================================================== //
@@ -37,6 +39,7 @@ interface AccountAction {
      * Get Specific UserInfo from URL
      * URL からユーザーを取得
      */
+    @JsExport.Ignore
     suspend fun user(url: String): User {
         throw NotImplementedException()
     }
@@ -230,6 +233,7 @@ interface AccountAction {
      * Get Comment from URL
      * URL からコメントを取得
      */
+    @JsExport.Ignore
     suspend fun comment(
         url: String
     ): Comment {

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/action/AccountActionImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/action/AccountActionImpl.kt
@@ -2,11 +2,14 @@ package work.socialhub.planetlink.action
 
 import work.socialhub.planetlink.model.Account
 import work.socialhub.planetlink.model.User
+import kotlin.js.JsExport
 
+@JsExport
 abstract class AccountActionImpl(
     var account: Account
 ) : AccountAction {
 
+    @JsExport.Ignore
     @Suppress("UNCHECKED_CAST")
     fun <T : AccountActionImpl> account(
         account: Account

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/action/CommentAction.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/action/CommentAction.kt
@@ -2,7 +2,9 @@ package work.socialhub.planetlink.action
 
 import work.socialhub.planetlink.model.Comment
 import work.socialhub.planetlink.model.Context
+import kotlin.js.JsExport
 
+@JsExport
 interface CommentAction {
 
     /**

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/action/RequestAction.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/action/RequestAction.kt
@@ -4,7 +4,9 @@ import work.socialhub.planetlink.action.request.CommentsRequest
 import work.socialhub.planetlink.action.request.UsersRequest
 import work.socialhub.planetlink.model.Identify
 import work.socialhub.planetlink.model.Request
+import kotlin.js.JsExport
 
+@JsExport
 interface RequestAction {
 
     // ============================================================== //

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/action/SerializedRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/action/SerializedRequest.kt
@@ -1,11 +1,14 @@
 package work.socialhub.planetlink.action
 
 import kotlinx.serialization.Serializable
+import kotlin.js.JsExport
 
+@JsExport
 @Serializable
 class SerializedRequest(
     var action: String
 ) {
+    @JsExport.Ignore
     constructor(
         action: Enum<*>
     ) : this(action.name)

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/action/ServiceAuth.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/action/ServiceAuth.kt
@@ -1,5 +1,8 @@
 package work.socialhub.planetlink.action
 
+import kotlin.js.JsExport
+
+@JsExport
 interface ServiceAuth<T> {
     val accessor: T
 }

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/action/UserAction.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/action/UserAction.kt
@@ -2,7 +2,9 @@ package work.socialhub.planetlink.action
 
 import work.socialhub.planetlink.model.Relationship
 import work.socialhub.planetlink.model.User
+import kotlin.js.JsExport
 
+@JsExport
 interface UserAction {
 
     /**

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/action/callback/EventCallback.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/action/callback/EventCallback.kt
@@ -1,3 +1,6 @@
 package work.socialhub.planetlink.action.callback
 
+import kotlin.js.JsExport
+
+@JsExport
 interface EventCallback 

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/action/callback/comment/DeleteCommentCallback.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/action/callback/comment/DeleteCommentCallback.kt
@@ -2,7 +2,9 @@ package work.socialhub.planetlink.action.callback.comment
 
 import work.socialhub.planetlink.action.callback.EventCallback
 import work.socialhub.planetlink.model.event.IdentifyEvent
+import kotlin.js.JsExport
 
+@JsExport
 interface DeleteCommentCallback : EventCallback {
     fun onDelete(event: IdentifyEvent?)
 }

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/action/callback/comment/MentionCommentCallback.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/action/callback/comment/MentionCommentCallback.kt
@@ -2,7 +2,9 @@ package work.socialhub.planetlink.action.callback.comment
 
 import net.socialhub.planetlink.model.event.CommentEvent
 import work.socialhub.planetlink.action.callback.EventCallback
+import kotlin.js.JsExport
 
+@JsExport
 interface MentionCommentCallback : EventCallback {
     fun onMention(event: CommentEvent?)
 }

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/action/callback/comment/NotificationCommentCallback.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/action/callback/comment/NotificationCommentCallback.kt
@@ -2,7 +2,9 @@ package work.socialhub.planetlink.action.callback.comment
 
 import work.socialhub.planetlink.action.callback.EventCallback
 import work.socialhub.planetlink.model.event.NotificationEvent
+import kotlin.js.JsExport
 
+@JsExport
 interface NotificationCommentCallback : EventCallback {
     fun onNotification(reaction: NotificationEvent?)
 }

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/action/callback/comment/ShareCommentCallback.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/action/callback/comment/ShareCommentCallback.kt
@@ -2,7 +2,9 @@ package work.socialhub.planetlink.action.callback.comment
 
 import net.socialhub.planetlink.model.event.CommentEvent
 import work.socialhub.planetlink.action.callback.EventCallback
+import kotlin.js.JsExport
 
+@JsExport
 interface ShareCommentCallback : EventCallback {
     fun onShare(event: CommentEvent?)
 }

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/action/callback/comment/UpdateCommentCallback.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/action/callback/comment/UpdateCommentCallback.kt
@@ -2,7 +2,9 @@ package work.socialhub.planetlink.action.callback.comment
 
 import net.socialhub.planetlink.model.event.CommentEvent
 import work.socialhub.planetlink.action.callback.EventCallback
+import kotlin.js.JsExport
 
+@JsExport
 interface UpdateCommentCallback : EventCallback {
     fun onUpdate(event: CommentEvent?)
 }

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/action/callback/lifecycle/ConnectCallback.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/action/callback/lifecycle/ConnectCallback.kt
@@ -1,7 +1,9 @@
 package work.socialhub.planetlink.action.callback.lifecycle
 
 import work.socialhub.planetlink.action.callback.EventCallback
+import kotlin.js.JsExport
 
+@JsExport
 interface ConnectCallback : EventCallback {
     fun onConnect()
 }

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/action/callback/lifecycle/DisconnectCallback.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/action/callback/lifecycle/DisconnectCallback.kt
@@ -1,7 +1,9 @@
 package work.socialhub.planetlink.action.callback.lifecycle
 
 import work.socialhub.planetlink.action.callback.EventCallback
+import kotlin.js.JsExport
 
+@JsExport
 interface DisconnectCallback : EventCallback {
     fun onDisconnect()
 }

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/action/callback/lifecycle/ErrorCallback.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/action/callback/lifecycle/ErrorCallback.kt
@@ -1,7 +1,9 @@
 package work.socialhub.planetlink.action.callback.lifecycle
 
 import work.socialhub.planetlink.action.callback.EventCallback
+import kotlin.js.JsExport
 
+@JsExport
 interface ErrorCallback: EventCallback {
     fun onError(e: Exception)
 }

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/action/callback/user/FollowUserCallback.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/action/callback/user/FollowUserCallback.kt
@@ -2,7 +2,9 @@ package work.socialhub.planetlink.action.callback.user
 
 import work.socialhub.planetlink.action.callback.EventCallback
 import work.socialhub.planetlink.model.event.UserEvent
+import kotlin.js.JsExport
 
+@JsExport
 interface FollowUserCallback : EventCallback {
     fun onFollow(event: UserEvent?)
 }

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/action/group/AccountGroupAction.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/action/group/AccountGroupAction.kt
@@ -2,7 +2,9 @@ package work.socialhub.planetlink.action.group
 
 import work.socialhub.planetlink.model.group.CommentGroup
 import work.socialhub.planetlink.model.group.UserGroup
+import kotlin.js.JsExport
 
+@JsExport
 interface AccountGroupAction {
 
     /**

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/action/group/CommentGroupAction.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/action/group/CommentGroupAction.kt
@@ -1,7 +1,9 @@
 package work.socialhub.planetlink.action.group
 
 import work.socialhub.planetlink.model.group.CommentGroup
+import kotlin.js.JsExport
 
+@JsExport
 interface CommentGroupAction {
 
     /**

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/action/group/CommentsRequestGroupAction.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/action/group/CommentsRequestGroupAction.kt
@@ -1,7 +1,9 @@
 package work.socialhub.planetlink.action.group
 
 import work.socialhub.planetlink.model.group.CommentGroup
+import kotlin.js.JsExport
 
+@JsExport
 interface CommentsRequestGroupAction {
 
     /**

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/action/group/UserGroupAction.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/action/group/UserGroupAction.kt
@@ -1,3 +1,6 @@
 package work.socialhub.planetlink.action.group
 
+import kotlin.js.JsExport
+
+@JsExport
 interface UserGroupAction 

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/action/group/UsersRequestGroupAction.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/action/group/UsersRequestGroupAction.kt
@@ -1,3 +1,6 @@
 package work.socialhub.planetlink.action.group
 
+import kotlin.js.JsExport
+
+@JsExport
 interface UsersRequestGroupAction 

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/action/request/CommentsRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/action/request/CommentsRequest.kt
@@ -3,7 +3,9 @@ package work.socialhub.planetlink.action.request
 import work.socialhub.planetlink.action.callback.EventCallback
 import work.socialhub.planetlink.model.*
 import work.socialhub.planetlink.model.request.CommentForm
+import kotlin.js.JsExport
 
+@JsExport
 interface CommentsRequest : Request {
 
     /**

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/action/request/CommentsRequestImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/action/request/CommentsRequestImpl.kt
@@ -6,7 +6,9 @@ import work.socialhub.planetlink.define.action.ActionType
 import work.socialhub.planetlink.model.*
 import work.socialhub.planetlink.model.error.NotSupportedException
 import work.socialhub.planetlink.model.request.CommentForm
+import kotlin.js.JsExport
 
+@JsExport
 class CommentsRequestImpl : CommentsRequest {
 
     var commentsFunction: (suspend (Paging) -> Pageable<Comment>)? = null

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/action/request/UsersRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/action/request/UsersRequest.kt
@@ -4,7 +4,9 @@ import work.socialhub.planetlink.model.Pageable
 import work.socialhub.planetlink.model.Paging
 import work.socialhub.planetlink.model.Request
 import work.socialhub.planetlink.model.User
+import kotlin.js.JsExport
 
+@JsExport
 interface UsersRequest : Request {
 
     /**

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/action/request/UsersRequestImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/action/request/UsersRequestImpl.kt
@@ -7,7 +7,9 @@ import work.socialhub.planetlink.model.Pageable
 import work.socialhub.planetlink.model.Paging
 import work.socialhub.planetlink.model.User
 import work.socialhub.planetlink.model.error.NotSupportedException
+import kotlin.js.JsExport
 
+@JsExport
 class UsersRequestImpl : UsersRequest {
 
     var usersFunction: (suspend (Paging) -> Pageable<User>)? = null

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/define/AttributedType.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/define/AttributedType.kt
@@ -7,7 +7,9 @@ import work.socialhub.planetlink.define.AttributedType.Regex.SIMPLE_PHONE_REGEX
 import work.socialhub.planetlink.model.common.AttributedKind
 import work.socialhub.planetlink.model.common.AttributedType
 import work.socialhub.planetlink.model.common.AttributedType.CommonAttributedType
+import kotlin.js.JsExport
 
+@JsExport
 object AttributedType {
 
     // Commons

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/define/ErrorType.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/define/ErrorType.kt
@@ -1,11 +1,13 @@
 package work.socialhub.planetlink.define
 
 import work.socialhub.planetlink.model.error.SocialHubError
+import kotlin.js.JsExport
 
 /**
  * Special Error for fur
  * 特殊対応を行う場合のエラーメッセージを追加
  */
+@JsExport
 enum class ErrorType(
     private val messageEn: String,
     private val messageJa: String

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/define/LanguageType.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/define/LanguageType.kt
@@ -1,9 +1,12 @@
 package work.socialhub.planetlink.define
 
+import kotlin.js.JsExport
+
 /**
  * Language list.
  * 対応言語一覧
  */
+@JsExport
 enum class LanguageType {
     ENGLISH,
     JAPANESE,

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/define/MediaType.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/define/MediaType.kt
@@ -1,8 +1,11 @@
 package work.socialhub.planetlink.define
 
+import kotlin.js.JsExport
+
 /**
  * Media Types
  */
+@JsExport
 enum class MediaType {
     Link,
     Image,

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/define/NotificationActionType.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/define/NotificationActionType.kt
@@ -1,8 +1,11 @@
 package work.socialhub.planetlink.define
 
+import kotlin.js.JsExport
+
 /**
  * Notification Action Types
  */
+@JsExport
 enum class NotificationActionType(
     val code: String
 ) {

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/define/ReactionType.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/define/ReactionType.kt
@@ -1,5 +1,8 @@
 package work.socialhub.planetlink.define
 
+import kotlin.js.JsExport
+
+@JsExport
 enum class ReactionType(
     val codes: String
 ) {

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/define/SpecialCharType.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/define/SpecialCharType.kt
@@ -1,11 +1,14 @@
 package work.socialhub.planetlink.define
 
+import kotlin.js.JsExport
+
 /**
  * Special char for xml
  * XHTML 内の特殊文字定義
  *
  * @link http://www.w3.org/TR/html4/charset.html
  */
+@JsExport
 enum class SpecialCharType(
     val entityRepl: String,
     val numberRepl: String,

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/define/action/ActionType.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/define/action/ActionType.kt
@@ -1,5 +1,7 @@
 package work.socialhub.planetlink.define.action
 
+import kotlin.js.JsExport
+
 /**
  * SNS アクション一覧
  * SNS Actions
@@ -8,4 +10,5 @@ package work.socialhub.planetlink.define.action
  * @see SocialActionType
  * @see UsersActionType
  */
+@JsExport
 interface ActionType 

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/define/action/GroupActionType.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/define/action/GroupActionType.kt
@@ -1,9 +1,12 @@
 package work.socialhub.planetlink.define.action
 
+import kotlin.js.JsExport
+
 /**
  * SNS グループアクション一覧
  * SNS Group Actions
  */
+@JsExport
 enum class GroupActionType {
     GetTimeLine,
     GetUserMe,

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/define/action/SocialActionType.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/define/action/SocialActionType.kt
@@ -1,5 +1,8 @@
 package work.socialhub.planetlink.define.action
 
+import kotlin.js.JsExport
+
+@JsExport
 enum class SocialActionType : ActionType {
 
     // Get Comment

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/define/action/TimeLineActionType.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/define/action/TimeLineActionType.kt
@@ -1,5 +1,8 @@
 package work.socialhub.planetlink.define.action
 
+import kotlin.js.JsExport
+
+@JsExport
 enum class TimeLineActionType : ActionType {
 
     // TimeLine

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/define/action/UsersActionType.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/define/action/UsersActionType.kt
@@ -1,5 +1,8 @@
 package work.socialhub.planetlink.define.action
 
+import kotlin.js.JsExport
+
+@JsExport
 enum class UsersActionType : ActionType {
 
     // Users

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/define/emoji/EmojiCategoryType.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/define/emoji/EmojiCategoryType.kt
@@ -1,5 +1,8 @@
 package work.socialhub.planetlink.define.emoji
 
+import kotlin.js.JsExport
+
+@JsExport
 enum class EmojiCategoryType(
     val code: String
 ) {

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/define/emoji/EmojiType.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/define/emoji/EmojiType.kt
@@ -1,5 +1,8 @@
 package work.socialhub.planetlink.define.emoji
 
+import kotlin.js.JsExport
+
+@JsExport
 @Suppress("unused")
 enum class EmojiType(
     val emoji: String,
@@ -1765,6 +1768,7 @@ enum class EmojiType(
     Secret("㊙️", "secret", "Symbols", 11),
     ;
 
+    @JsExport.Ignore
     fun category(): EmojiCategoryType {
         return EmojiCategoryType.of(category)
     }

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/define/emoji/EmojiVariationType.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/define/emoji/EmojiVariationType.kt
@@ -1,5 +1,8 @@
 package work.socialhub.planetlink.define.emoji
 
+import kotlin.js.JsExport
+
+@JsExport
 @Suppress("unused")
 enum class EmojiVariationType(
     val emoji: String,
@@ -1367,6 +1370,7 @@ enum class EmojiVariationType(
     WritingHandSkinTone6("✍🏿", "writing_hand::skin-tone-6", "People & Body", null),
     ;
 
+    @JsExport.Ignore
     fun category(): EmojiCategoryType {
         return EmojiCategoryType.of(category)
     }

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/micro/MicroBlogComment.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/micro/MicroBlogComment.kt
@@ -3,7 +3,9 @@ package work.socialhub.planetlink.micro
 import work.socialhub.planetlink.model.Comment
 import work.socialhub.planetlink.model.Identify
 import work.socialhub.planetlink.model.Service
+import kotlin.js.JsExport
 
+@JsExport
 open class MicroBlogComment(
     service: Service
 ) : Comment(service) {

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/micro/MicroBlogUser.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/micro/MicroBlogUser.kt
@@ -2,7 +2,9 @@ package work.socialhub.planetlink.micro
 
 import work.socialhub.planetlink.model.Service
 import work.socialhub.planetlink.model.User
+import kotlin.js.JsExport
 
+@JsExport
 open class MicroBlogUser(
     service: Service
 ) : User(service) {

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Account.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Account.kt
@@ -1,6 +1,7 @@
 package work.socialhub.planetlink.model
 
 import work.socialhub.planetlink.action.AccountAction
+import kotlin.js.JsExport
 
 /**
  * Account Model
@@ -8,6 +9,7 @@ import work.socialhub.planetlink.action.AccountAction
  * アカウント情報を扱うモデル
  * (各サービス毎のユーザーではない点に注意)
  */
+@JsExport
 class Account {
 
     var tag: String? = null

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Application.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Application.kt
@@ -1,9 +1,12 @@
 package work.socialhub.planetlink.model
 
+import kotlin.js.JsExport
+
 /**
  * Application posted by
  * 投稿されたアプリケーション
  */
+@JsExport
 class Application {
     var name: String? = null
     var website: String? = null

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Channel.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Channel.kt
@@ -1,11 +1,13 @@
 package work.socialhub.planetlink.model
 
 import kotlinx.datetime.Instant
+import kotlin.js.JsExport
 
 /**
  * SNS チャンネル (リスト) 情報
  * SNS Channel (List) Model
  */
+@JsExport
 open class Channel(
     service: Service
 ) : Identify(service) {

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Comment.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Comment.kt
@@ -6,11 +6,13 @@ import work.socialhub.planetlink.action.CommentActionImpl
 import work.socialhub.planetlink.model.common.AttributedString
 import work.socialhub.planetlink.model.error.NotImplementedException
 import work.socialhub.planetlink.model.request.CommentForm
+import kotlin.js.JsExport
 
 /**
  * SNS コメント情報
  * SNS Comment Model
  */
+@JsExport
 open class Comment(
     service: Service
 ) : Identify(service) {

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Context.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Context.kt
@@ -1,8 +1,11 @@
 package work.socialhub.planetlink.model
 
+import kotlin.js.JsExport
+
 /**
  * Comment Context
  */
+@JsExport
 class Context {
 
     /**

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Emoji.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Emoji.kt
@@ -2,10 +2,12 @@ package work.socialhub.planetlink.model
 
 import work.socialhub.planetlink.define.emoji.EmojiType
 import work.socialhub.planetlink.define.emoji.EmojiVariationType
+import kotlin.js.JsExport
 
 /**
  * Emoji
  */
+@JsExport
 class Emoji {
 
     /**

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Error.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Error.kt
@@ -2,7 +2,9 @@ package work.socialhub.planetlink.model
 
 import work.socialhub.planetlink.define.LanguageType
 import work.socialhub.planetlink.model.error.SocialHubError
+import kotlin.js.JsExport
 
+@JsExport
 class Error(
     private val messageForUser: String
 ) : SocialHubError {

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Identify.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Identify.kt
@@ -1,20 +1,25 @@
 package work.socialhub.planetlink.model
 
+import kotlin.js.JsExport
+
 /**
  * Identify
  * 識別
  */
+@JsExport
 open class Identify(
     var service: Service
 ) {
     var id: ID? = null
 
+    @JsExport.Ignore
     inline fun <reified T> id(): T {
         return checkNotNull(id) {
             "id is null."
         }.value<T>()
     }
 
+    @JsExport.Ignore
     constructor(
         service: Service,
         id: ID,

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Instance.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Instance.kt
@@ -1,10 +1,13 @@
 package work.socialhub.planetlink.model
 
+import kotlin.js.JsExport
+
 /**
  * インスタンス情報
  * Instance Info
  * (for distributed SNS)
  */
+@JsExport
 class Instance(
     var service: Service
 ) {

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Media.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Media.kt
@@ -1,11 +1,13 @@
 package work.socialhub.planetlink.model
 
 import work.socialhub.planetlink.define.MediaType
+import kotlin.js.JsExport
 
 /**
  * Media Model
  * メディアモデル
  */
+@JsExport
 class Media {
 
     /** Type of this media */

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Notification.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Notification.kt
@@ -2,11 +2,13 @@ package work.socialhub.planetlink.model
 
 import kotlinx.datetime.Instant
 import work.socialhub.planetlink.define.NotificationActionType
+import kotlin.js.JsExport
 
 /**
  * Notification
  * 通知
  */
+@JsExport
 open class Notification(
     service: Service
 ) : Identify(service) {

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Pageable.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Pageable.kt
@@ -1,9 +1,12 @@
 package work.socialhub.planetlink.model
 
+import kotlin.js.JsExport
+
 /**
  * ページング可能レスポンス
  * Pageable Response
  */
+@JsExport
 class Pageable<T : Identify> {
 
     /** Paging Information  */

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Paging.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Paging.kt
@@ -1,6 +1,7 @@
 package work.socialhub.planetlink.model
 
 import work.socialhub.planetlink.model.paging.*
+import kotlin.js.JsExport
 
 /**
  * Paging
@@ -13,6 +14,7 @@ import work.socialhub.planetlink.model.paging.*
  * @see IndexPaging
  * @see OffsetPaging
  */
+@JsExport
 open class Paging(
     var count: Int? = null,
 ) {

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Poll.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Poll.kt
@@ -2,11 +2,13 @@ package work.socialhub.planetlink.model
 
 import kotlinx.datetime.Instant
 import work.socialhub.planetlink.model.support.PollOption
+import kotlin.js.JsExport
 
 /**
  * Poll
  * 投票情報
  */
+@JsExport
 open class Poll(
     service: Service
 ) : Identify(service) {

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/RateLimit.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/RateLimit.kt
@@ -3,11 +3,13 @@ package work.socialhub.planetlink.model
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import work.socialhub.planetlink.define.action.ActionType
+import kotlin.js.JsExport
 
 /**
  * SNS レートリミット
  * SNS RateLimit
  */
+@JsExport
 class RateLimit {
 
     private val dictionary = mutableMapOf<ActionType, RateLimitValue>()
@@ -16,6 +18,7 @@ class RateLimit {
      * レートリミット情報を格納
      * Set rate limit info
      */
+    @JsExport.Ignore
     fun addInfo(
         action: ActionType,
         service: String,

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Reaction.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Reaction.kt
@@ -1,9 +1,12 @@
 package work.socialhub.planetlink.model
 
+import kotlin.js.JsExport
+
 /**
  * Reaction Model
  * リアクションモデル
  */
+@JsExport
 class Reaction {
 
     var name: String? = null

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Relationship.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Relationship.kt
@@ -1,9 +1,12 @@
 package work.socialhub.planetlink.model
 
+import kotlin.js.JsExport
+
 /**
  * Relationship between accounts
  * アカウント間の関係を取得
  */
+@JsExport
 class Relationship {
     var followed: Boolean = false
     var following: Boolean = false

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Request.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Request.kt
@@ -4,11 +4,13 @@ import kotlinx.serialization.encodeToString
 import work.socialhub.planetlink.action.SerializedRequest
 import work.socialhub.planetlink.define.action.ActionType
 import work.socialhub.planetlink.utils.SerializeUtil
+import kotlin.js.JsExport
 
 /**
  * Common Request Interface
  * リクエスト汎用インターフェース
  */
+@JsExport
 interface Request {
 
     /**

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Service.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Service.kt
@@ -1,9 +1,12 @@
 package work.socialhub.planetlink.model
 
+import kotlin.js.JsExport
+
 /**
  * SNS サービス情報
  * SNS Service Info
  */
+@JsExport
 class Service(
     var type: String,
     var account: Account,

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Stream.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Stream.kt
@@ -1,9 +1,12 @@
 package work.socialhub.planetlink.model
 
+import kotlin.js.JsExport
+
 /**
  * Stream
  * ストリーム操作 API
  */
+@JsExport
 interface Stream {
     suspend fun open()
     fun close()

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Thread.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Thread.kt
@@ -1,11 +1,13 @@
 package work.socialhub.planetlink.model
 
 import kotlinx.datetime.Instant
+import kotlin.js.JsExport
 
 /**
  * Thread of Group Messaging
  * グループメッセージスレッド
  */
+@JsExport
 open class Thread(
     service: Service
 ) : Identify(service) {

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Trend.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/Trend.kt
@@ -1,5 +1,8 @@
 package work.socialhub.planetlink.model
 
+import kotlin.js.JsExport
+
+@JsExport
 class Trend {
     var name: String? = null
     var query: String? = null

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/User.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/User.kt
@@ -5,11 +5,13 @@ import work.socialhub.planetlink.model.common.AttributedFiled
 import work.socialhub.planetlink.model.common.AttributedString
 import work.socialhub.planetlink.model.error.NotImplementedException
 import work.socialhub.planetlink.model.request.CommentForm
+import kotlin.js.JsExport
 
 /**
  * SNS ユーザーモデル
  * SNS User Model
  */
+@JsExport
 open class User(
     service: Service
 ) : Identify(service) {

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/common/AttributedBucket.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/common/AttributedBucket.kt
@@ -1,6 +1,9 @@
 package work.socialhub.planetlink.model.common
 
+import kotlin.js.JsExport
 
+
+@JsExport
 class AttributedBucket : AttributedElement {
 
     override var kind = AttributedKind.OTHER

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/common/AttributedElement.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/common/AttributedElement.kt
@@ -1,9 +1,12 @@
 package work.socialhub.planetlink.model.common
 
+import kotlin.js.JsExport
+
 /**
  * Attributes Elements
  * 属性情報
  */
+@JsExport
 interface AttributedElement {
 
     /** Type of element */

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/common/AttributedFiled.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/common/AttributedFiled.kt
@@ -1,19 +1,24 @@
 package work.socialhub.planetlink.model.common
 
+import kotlin.js.JsExport
+
 /**
  * 追加フィールド
  * Extra Fields
  */
+@JsExport
 class AttributedFiled {
 
     var name: String? = null
     var value: AttributedString? = null
 
+    @JsExport.Ignore
     constructor(name: String?, value: AttributedString?) {
         this.value = value
         this.name = name
     }
 
+    @JsExport.Ignore
     constructor(name: String?, value: String?) {
         this.value = AttributedString.plain(value)
         this.name = name

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/common/AttributedItem.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/common/AttributedItem.kt
@@ -1,5 +1,8 @@
 package work.socialhub.planetlink.model.common
 
+import kotlin.js.JsExport
+
+@JsExport
 class AttributedItem : AttributedElement {
 
     override var kind: AttributedKind = AttributedKind.OTHER

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/common/AttributedKind.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/common/AttributedKind.kt
@@ -1,5 +1,8 @@
 package work.socialhub.planetlink.model.common
 
+import kotlin.js.JsExport
+
+@JsExport
 enum class AttributedKind {
 
     // STRINGS

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/common/AttributedString.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/common/AttributedString.kt
@@ -2,11 +2,13 @@ package work.socialhub.planetlink.model.common
 
 import work.socialhub.planetlink.define.AttributedType.simple
 import work.socialhub.planetlink.model.Emoji
+import kotlin.js.JsExport
 
 /**
  * String With Attributes
  * 属性付き文字列
  */
+@JsExport
 class AttributedString {
 
     var elements: List<AttributedElement>
@@ -15,6 +17,7 @@ class AttributedString {
      * Make Attributes String with AttributedElements list.
      * 属性付き要素から属性付き文字列を生成
      */
+    @JsExport.Ignore
     constructor(elements: List<AttributedElement>) {
         this.elements = elements
     }
@@ -23,6 +26,7 @@ class AttributedString {
      * Attributed String with plain text and element types.
      * 文字列から属性文字列を作成 (属性を指定)
      */
+    @JsExport.Ignore
     private constructor(text: String, kinds: List<AttributedType>) {
         val model = AttributedItem()
         model.kind = AttributedKind.PLAIN
@@ -208,6 +212,7 @@ class AttributedString {
          * Make Attributed String from plain text.
          * 装飾無しテキストから属性付き文字列を作成
          */
+        @JsExport.Ignore
         fun plain(string: String?): AttributedString {
             return AttributedString(if ((string != null)) string else "", simple())
         }

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/common/AttributedType.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/common/AttributedType.kt
@@ -1,5 +1,8 @@
 package work.socialhub.planetlink.model.common
 
+import kotlin.js.JsExport
+
+@JsExport
 interface AttributedType {
 
     /** 属性の種類を取得 */
@@ -17,6 +20,7 @@ interface AttributedType {
     /**
      * AttributedType のデフォルト実装
      */
+    @JsExport.Ignore
     class CommonAttributedType(
         override val kind: AttributedKind,
         override val regex: Regex,
@@ -24,6 +28,7 @@ interface AttributedType {
         val expand: ((MatchResult) -> String)?,
     ) : AttributedType {
 
+        @JsExport.Ignore
         constructor(
             kind: AttributedKind,
             regex: Regex

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/error/NotImplementedException.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/error/NotImplementedException.kt
@@ -1,3 +1,6 @@
 package work.socialhub.planetlink.model.error
 
+import kotlin.js.JsExport
+
+@JsExport
 class NotImplementedException : SocialHubException()

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/error/NotSupportedException.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/error/NotSupportedException.kt
@@ -1,6 +1,11 @@
 package work.socialhub.planetlink.model.error
 
+import kotlin.js.JsExport
+
+@JsExport
 class NotSupportedException : SocialHubException {
+    @JsExport.Ignore
     constructor() : super()
+    @JsExport.Ignore
     constructor(message: String) : super(message)
 }

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/error/SocialHubError.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/error/SocialHubError.kt
@@ -1,7 +1,9 @@
 package work.socialhub.planetlink.model.error
 
 import work.socialhub.planetlink.define.LanguageType
+import kotlin.js.JsExport
 
+@JsExport
 interface SocialHubError {
 
     /**
@@ -14,5 +16,6 @@ interface SocialHubError {
      * Get error message with specified language
      * 言語を指定してエラーメッセージを取得
      */
+    @JsExport.Ignore
     fun messageForUser(language: LanguageType): String
 }

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/error/SocialHubException.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/error/SocialHubException.kt
@@ -1,5 +1,8 @@
 package work.socialhub.planetlink.model.error
 
+import kotlin.js.JsExport
+
+@JsExport
 open class SocialHubException : RuntimeException {
 
     /**
@@ -8,11 +11,15 @@ open class SocialHubException : RuntimeException {
      */
     var error: SocialHubError? = null
 
+    @JsExport.Ignore
     constructor() : super()
 
+    @JsExport.Ignore
     constructor(message: String) : super(message)
 
+    @JsExport.Ignore
     constructor(message: String?, cause: Throwable?) : super(message, cause)
 
+    @JsExport.Ignore
     constructor(cause: Throwable) : super(cause)
 }

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/event/CommentEvent.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/event/CommentEvent.kt
@@ -2,7 +2,9 @@ package net.socialhub.planetlink.model.event
 
 
 import work.socialhub.planetlink.model.Comment
+import kotlin.js.JsExport
 
+@JsExport
 class CommentEvent(
     var comment: Comment
 )

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/event/IdentifyEvent.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/event/IdentifyEvent.kt
@@ -1,5 +1,8 @@
 package work.socialhub.planetlink.model.event
 
+import kotlin.js.JsExport
+
+@JsExport
 class IdentifyEvent(
     var id: Any
 )

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/event/NotificationEvent.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/event/NotificationEvent.kt
@@ -1,7 +1,9 @@
 package work.socialhub.planetlink.model.event
 
 import work.socialhub.planetlink.model.Notification
+import kotlin.js.JsExport
 
+@JsExport
 class NotificationEvent(
     var notification: Notification
 )

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/event/UserEvent.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/event/UserEvent.kt
@@ -1,7 +1,9 @@
 package work.socialhub.planetlink.model.event
 
 import work.socialhub.planetlink.model.User
+import kotlin.js.JsExport
 
+@JsExport
 class UserEvent(
     var user: User
 )

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/group/AccountGroup.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/group/AccountGroup.kt
@@ -2,11 +2,13 @@ package work.socialhub.planetlink.model.group
 
 import work.socialhub.planetlink.action.group.AccountGroupAction
 import work.socialhub.planetlink.model.Account
+import kotlin.js.JsExport
 
 /**
  * Account Group Model
  * 複数のアカウントを束ねるモデル
  */
+@JsExport
 interface AccountGroup {
 
     /**

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/group/AccountGroupImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/group/AccountGroupImpl.kt
@@ -3,7 +3,9 @@ package work.socialhub.planetlink.model.group
 import work.socialhub.planetlink.action.group.AccountGroupAction
 import work.socialhub.planetlink.action.group.AccountGroupActionImpl
 import work.socialhub.planetlink.model.Account
+import kotlin.js.JsExport
 
+@JsExport
 class AccountGroupImpl(
     vararg accounts: Account
 ) : AccountGroup {

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/group/CommentGroup.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/group/CommentGroup.kt
@@ -5,7 +5,9 @@ import work.socialhub.planetlink.action.group.CommentGroupAction
 import work.socialhub.planetlink.action.request.CommentsRequest
 import work.socialhub.planetlink.model.Comment
 import work.socialhub.planetlink.model.Pageable
+import kotlin.js.JsExport
 
+@JsExport
 interface CommentGroup {
 
     /**

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/group/CommentGroupImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/group/CommentGroupImpl.kt
@@ -7,10 +7,12 @@ import work.socialhub.planetlink.action.request.CommentsRequest
 import work.socialhub.planetlink.model.Comment
 import work.socialhub.planetlink.model.Pageable
 import work.socialhub.planetlink.model.Paging
+import kotlin.js.JsExport
 
 /**
  * Whole Accounts Comments
  */
+@JsExport
 class CommentGroupImpl(
     /** Comments Request Group  */
     override var requestGroup: CommentsRequestGroup,

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/group/CommentsRequestGroup.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/group/CommentsRequestGroup.kt
@@ -2,7 +2,9 @@ package work.socialhub.planetlink.model.group
 
 import work.socialhub.planetlink.action.group.CommentsRequestGroupAction
 import work.socialhub.planetlink.action.request.CommentsRequest
+import kotlin.js.JsExport
 
+@JsExport
 interface CommentsRequestGroup {
 
     val requests: MutableList<CommentsRequest>
@@ -10,6 +12,7 @@ interface CommentsRequestGroup {
     /**
      * Add Comments Request
      */
+    @JsExport.Ignore
     fun addCommentsRequests(request: CommentsRequest)
 
     /**
@@ -23,6 +26,7 @@ interface CommentsRequestGroup {
     fun action(): CommentsRequestGroupAction
 
     companion object {
+        @JsExport.Ignore
         fun of(): CommentsRequestGroup {
             return CommentsRequestGroupImpl()
         }

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/group/CommentsRequestGroupImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/group/CommentsRequestGroupImpl.kt
@@ -3,7 +3,9 @@ package work.socialhub.planetlink.model.group
 import work.socialhub.planetlink.action.group.CommentsRequestGroupAction
 import work.socialhub.planetlink.action.group.CommentsRequestGroupActionImpl
 import work.socialhub.planetlink.action.request.CommentsRequest
+import kotlin.js.JsExport
 
+@JsExport
 class CommentsRequestGroupImpl(
     vararg requests: CommentsRequest
 ) : CommentsRequestGroup {
@@ -18,6 +20,7 @@ class CommentsRequestGroupImpl(
     /**
      * {@inheritDoc}
      */
+    @JsExport.Ignore
     override fun addCommentsRequests(request: CommentsRequest) {
         this.requests.add(request)
     }

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/group/UserGroup.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/group/UserGroup.kt
@@ -3,7 +3,9 @@ package work.socialhub.planetlink.model.group
 import work.socialhub.planetlink.action.group.UserGroupAction
 import work.socialhub.planetlink.model.Account
 import work.socialhub.planetlink.model.User
+import kotlin.js.JsExport
 
+@JsExport
 interface UserGroup {
 
     /**

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/group/UserGroupImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/group/UserGroupImpl.kt
@@ -4,7 +4,9 @@ import work.socialhub.planetlink.action.group.UserGroupAction
 import work.socialhub.planetlink.action.group.UserGroupActionImpl
 import work.socialhub.planetlink.model.Account
 import work.socialhub.planetlink.model.User
+import kotlin.js.JsExport
 
+@JsExport
 class UserGroupImpl(
     override var entities: Map<Account, User>
 ) : UserGroup {

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/group/UsersRequestGroup.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/group/UsersRequestGroup.kt
@@ -2,7 +2,9 @@ package work.socialhub.planetlink.model.group
 
 import work.socialhub.planetlink.action.group.UsersRequestGroupAction
 import work.socialhub.planetlink.action.request.UsersRequest
+import kotlin.js.JsExport
 
+@JsExport
 interface UsersRequestGroup {
 
     val requests: MutableList<UsersRequest>
@@ -10,6 +12,7 @@ interface UsersRequestGroup {
     /**
      * Add Users Request
      */
+    @JsExport.Ignore
     fun addUsersRequests(request: UsersRequest)
 
     /**
@@ -23,6 +26,7 @@ interface UsersRequestGroup {
     fun action(): UsersRequestGroupAction
 
     companion object {
+        @JsExport.Ignore
         fun of(): UsersRequestGroup {
             return UsersRequestGroupImpl()
         }

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/group/UsersRequestGroupImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/group/UsersRequestGroupImpl.kt
@@ -3,7 +3,9 @@ package work.socialhub.planetlink.model.group
 import work.socialhub.planetlink.action.group.UsersRequestGroupAction
 import work.socialhub.planetlink.action.group.UsersRequestGroupActionImpl
 import work.socialhub.planetlink.action.request.UsersRequest
+import kotlin.js.JsExport
 
+@JsExport
 class UsersRequestGroupImpl(
     vararg requests: UsersRequest
 ) : UsersRequestGroup {
@@ -18,6 +20,7 @@ class UsersRequestGroupImpl(
     /**
      * {@inheritDoc}
      */
+    @JsExport.Ignore
     override fun addUsersRequests(request: UsersRequest) {
         requests.add(request)
     }

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/paging/BorderPaging.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/paging/BorderPaging.kt
@@ -2,12 +2,14 @@ package work.socialhub.planetlink.model.paging
 
 import work.socialhub.planetlink.model.Identify
 import work.socialhub.planetlink.model.Paging
+import kotlin.js.JsExport
 
 /**
  * Paging with max and since
  * Max Since 管理のページング
  * (Twitter, Mastodon etc.)
  */
+@JsExport
 class BorderPaging(
     count: Int? = null,
 ) : Paging(count) {

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/paging/CursorPaging.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/paging/CursorPaging.kt
@@ -2,12 +2,14 @@ package work.socialhub.planetlink.model.paging
 
 import work.socialhub.planetlink.model.Identify
 import work.socialhub.planetlink.model.Paging
+import kotlin.js.JsExport
 
 /**
  * Paging with cursor
  * カーソル付きページング
  * (Twitter, Slack etc.)
  */
+@JsExport
 class CursorPaging<Type>(
     count: Int? = null,
 ) : Paging(count) {

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/paging/DatePaging.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/paging/DatePaging.kt
@@ -2,12 +2,14 @@ package work.socialhub.planetlink.model.paging
 
 import work.socialhub.planetlink.model.Identify
 import work.socialhub.planetlink.model.Paging
+import kotlin.js.JsExport
 
 /**
  * Paging with date range
  * 時間範囲指定
  * (Slack)
  */
+@JsExport
 class DatePaging : Paging() {
 
     var latest: String? = null

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/paging/IndexPaging.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/paging/IndexPaging.kt
@@ -2,11 +2,13 @@ package work.socialhub.planetlink.model.paging
 
 import work.socialhub.planetlink.model.Identify
 import work.socialhub.planetlink.model.Paging
+import kotlin.js.JsExport
 
 /**
  * Paging with page number
  * ベージ番号付きページング
  */
+@JsExport
 class IndexPaging : Paging() {
 
     var page: Long? = null

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/paging/OffsetPaging.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/paging/OffsetPaging.kt
@@ -2,7 +2,9 @@ package work.socialhub.planetlink.model.paging
 
 import work.socialhub.planetlink.model.Identify
 import work.socialhub.planetlink.model.Paging
+import kotlin.js.JsExport
 
+@JsExport
 class OffsetPaging : Paging() {
 
     var offset: Int? = null

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/paging/RangePaging.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/paging/RangePaging.kt
@@ -3,11 +3,13 @@ package work.socialhub.planetlink.model.paging
 import work.socialhub.planetlink.model.ID
 import work.socialhub.planetlink.model.Identify
 import work.socialhub.planetlink.model.Paging
+import kotlin.js.JsExport
 
 /**
  * ID の開始と終了を指定するページング
  * (start,end の片方のみを指定する)
  */
+@JsExport
 class RangePaging(
     count: Int? = null,
 ) : Paging(count) {

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/request/CommentForm.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/request/CommentForm.kt
@@ -1,7 +1,9 @@
 package work.socialhub.planetlink.model.request
 
 import work.socialhub.planetlink.model.ID
+import kotlin.js.JsExport
 
+@JsExport
 class CommentForm {
 
     /** Text  */
@@ -57,6 +59,7 @@ class CommentForm {
     /**
      * Set Text
      */
+    @JsExport.Ignore
     fun text(text: String?): CommentForm {
         this.text = text
         return this
@@ -65,6 +68,7 @@ class CommentForm {
     /**
      * Set Warning
      */
+    @JsExport.Ignore
     fun warning(warning: String?): CommentForm {
         this.warning = warning
         return this
@@ -73,6 +77,7 @@ class CommentForm {
     /**
      * Set Reply (Thread) ID
      */
+    @JsExport.Ignore
     fun replyId(replyId: ID?): CommentForm {
         this.replyId = replyId
         return this
@@ -81,6 +86,7 @@ class CommentForm {
     /**
      * Set Quote ID
      */
+    @JsExport.Ignore
     fun quoteId(quoteId: ID?): CommentForm {
         this.quoteId = quoteId
         return this
@@ -89,6 +95,7 @@ class CommentForm {
     /**
      * Add One File
      */
+    @JsExport.Ignore
     fun addImage(data: ByteArray, name: String): CommentForm {
         return addImage(MediaForm(data, name))
     }
@@ -96,6 +103,7 @@ class CommentForm {
     /**
      * Add One Image
      */
+    @JsExport.Ignore
     fun addImage(req: MediaForm): CommentForm {
         images.add(req)
         return this
@@ -112,6 +120,7 @@ class CommentForm {
     /**
      * Set Sensitive
      */
+    @JsExport.Ignore
     fun isSensitive(isSensitive: Boolean): CommentForm {
         this.isSensitive = isSensitive
         return this
@@ -120,6 +129,7 @@ class CommentForm {
     /**
      * Set Message
      */
+    @JsExport.Ignore
     fun isMessage(isMessage: Boolean): CommentForm {
         this.isMessage = isMessage
         return this
@@ -128,6 +138,7 @@ class CommentForm {
     /**
      * Visibility
      */
+    @JsExport.Ignore
     fun visibility(visibility: String?): CommentForm {
         this.visibility = visibility
         return this
@@ -136,6 +147,7 @@ class CommentForm {
     /**
      * Set Poll
      */
+    @JsExport.Ignore
     fun poll(poll: PollForm?): CommentForm {
         this.poll = poll
         return this

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/request/MediaForm.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/request/MediaForm.kt
@@ -1,6 +1,9 @@
 package work.socialhub.planetlink.model.request
 
+import kotlin.js.JsExport
 
+
+@JsExport
 class MediaForm(
     /** Media Data  */
     var data: ByteArray,

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/request/PollForm.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/request/PollForm.kt
@@ -1,5 +1,8 @@
 package work.socialhub.planetlink.model.request
 
+import kotlin.js.JsExport
+
+@JsExport
 class PollForm {
 
     val options = mutableListOf<String>()
@@ -21,6 +24,7 @@ class PollForm {
     /**
      * Set multiple
      */
+    @JsExport.Ignore
     fun multiple(multiple: Boolean): PollForm {
         this.multiple = multiple
         return this
@@ -29,6 +33,7 @@ class PollForm {
     /**
      * Set expires in (min)
      */
+    @JsExport.Ignore
     fun expiresIn(expiresIn: Int): PollForm {
         this.expiresIn = expiresIn
         return this

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/support/Color.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/support/Color.kt
@@ -1,9 +1,12 @@
 package work.socialhub.planetlink.model.support
 
+import kotlin.js.JsExport
+
 /**
  * Color Model
  * Initialize with white color.
  */
+@JsExport
 class Color(
     var r: Int = 255,
     var g: Int = 255,

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/support/PollOption.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/support/PollOption.kt
@@ -1,9 +1,12 @@
 package work.socialhub.planetlink.model.support
 
+import kotlin.js.JsExport
+
 /**
  * Poll's Option
  * 投票における選択肢
  */
+@JsExport
 class PollOption(
     var index: Int,
     var title: String = "",

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/support/TrendComment.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/support/TrendComment.kt
@@ -2,7 +2,9 @@ package work.socialhub.planetlink.model.support
 
 import work.socialhub.planetlink.model.Comment
 import work.socialhub.planetlink.model.Trend
+import kotlin.js.JsExport
 
+@JsExport
 class TrendComment(
     var trend: Trend?,
     var comment: Comment?,

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/support/TrendCountry.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/support/TrendCountry.kt
@@ -1,5 +1,8 @@
 package work.socialhub.planetlink.model.support
 
+import kotlin.js.JsExport
+
+@JsExport
 class TrendCountry {
     var id: Int? = null
     var name: String? = null

--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/model/support/TupleIdentify.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/model/support/TupleIdentify.kt
@@ -3,7 +3,9 @@ package work.socialhub.planetlink.model.support
 import work.socialhub.planetlink.model.ID
 import work.socialhub.planetlink.model.Identify
 import work.socialhub.planetlink.model.Service
+import kotlin.js.JsExport
 
+@JsExport
 class TupleIdentify(
     service: Service
 ) : Identify(service) {

--- a/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/define/MastodonActionType.kt
+++ b/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/define/MastodonActionType.kt
@@ -1,7 +1,9 @@
 package work.socialhub.planetlink.mastodon.define
 
 import work.socialhub.planetlink.define.action.ActionType
+import kotlin.js.JsExport
 
+@JsExport
 enum class MastodonActionType : ActionType {
     LocalTimeLine,
     FederationTimeLine,

--- a/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/define/MastodonImageSize.kt
+++ b/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/define/MastodonImageSize.kt
@@ -1,5 +1,8 @@
 package work.socialhub.planetlink.mastodon.define
 
+import kotlin.js.JsExport
+
+@JsExport
 enum class MastodonImageSize(
     val code: String
 ) {

--- a/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/define/MastodonInstance.kt
+++ b/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/define/MastodonInstance.kt
@@ -1,9 +1,12 @@
 package work.socialhub.planetlink.mastodon.define
 
+import kotlin.js.JsExport
+
 /**
  * Famous Mastodon Instances
  * 有名 Mastodon インスタンスプリセット
  */
+@JsExport
 object MastodonInstance {
 
     // Mastodon

--- a/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/define/MastodonMediaType.kt
+++ b/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/define/MastodonMediaType.kt
@@ -1,5 +1,8 @@
 package work.socialhub.planetlink.mastodon.define
 
+import kotlin.js.JsExport
+
+@JsExport
 enum class MastodonMediaType(
     vararg val codes: String
 ) {

--- a/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/define/MastodonNotificationType.kt
+++ b/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/define/MastodonNotificationType.kt
@@ -1,7 +1,9 @@
 package work.socialhub.planetlink.mastodon.define
 
 import work.socialhub.planetlink.define.NotificationActionType
+import kotlin.js.JsExport
 
+@JsExport
 enum class MastodonNotificationType(
     val action: NotificationActionType?,
     val code: String

--- a/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/define/MastodonReactionType.kt
+++ b/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/define/MastodonReactionType.kt
@@ -1,9 +1,12 @@
 package work.socialhub.planetlink.mastodon.define
 
+import kotlin.js.JsExport
+
 /**
  * Mastodon Reaction Type
  * (Action code with alias)
  */
+@JsExport
 enum class MastodonReactionType(
     vararg val codes: String
 ) {

--- a/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/define/MastodonScope.kt
+++ b/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/define/MastodonScope.kt
@@ -1,10 +1,13 @@
 package work.socialhub.planetlink.mastodon.define
 
+import kotlin.js.JsExport
+
 
 /**
  * Mastodon Authorization Scopes
  * Mastodon 認証用スコープリスト
  */
+@JsExport
 object MastodonScope {
     const val READ: String = "read"
     const val WRITE: String = "write"

--- a/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/define/MastodonVisibility.kt
+++ b/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/define/MastodonVisibility.kt
@@ -1,5 +1,8 @@
 package work.socialhub.planetlink.mastodon.define
 
+import kotlin.js.JsExport
+
+@JsExport
 enum class MastodonVisibility(
     val code: String
 ) {

--- a/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/expand/AttributedStringEx.kt
+++ b/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/expand/AttributedStringEx.kt
@@ -6,7 +6,9 @@ import work.socialhub.planetlink.model.common.AttributedElement
 import work.socialhub.planetlink.model.common.AttributedItem
 import work.socialhub.planetlink.model.common.AttributedKind
 import work.socialhub.planetlink.model.common.AttributedString
+import kotlin.js.JsExport
 
+@JsExport
 object AttributedStringEx {
 
     data class Tag(

--- a/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/expand/PlanetLinkEx.kt
+++ b/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/expand/PlanetLinkEx.kt
@@ -2,7 +2,9 @@ package work.socialhub.planetlink.mastodon.expand
 
 import work.socialhub.planetlink.PlanetLink
 import work.socialhub.planetlink.mastodon.action.MastodonAuth
+import kotlin.js.JsExport
 
+@JsExport
 object PlanetLinkEx {
 
     /**

--- a/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/expand/ServiceEx.kt
+++ b/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/expand/ServiceEx.kt
@@ -1,7 +1,9 @@
 package work.socialhub.planetlink.mastodon.expand
 
 import work.socialhub.planetlink.model.Service
+import kotlin.js.JsExport
 
+@JsExport
 object ServiceEx {
 
     /**
@@ -10,6 +12,7 @@ object ServiceEx {
      * !! if pixelfed, use SocialHub#getPixelFedAuth to make account object.
      * !! if pleroma, use SocialHub#getPleromaAuth to make account object.
      */
+    @JsExport.Ignore
     val Service.isMastodon: Boolean
         get() = ("mastodon" == type.lowercase())
 
@@ -18,6 +21,7 @@ object ServiceEx {
      * !! Mastodon compatibility account is always false.
      * !! Use SocialHub#getPixelFedAuth to make account object.
      */
+    @JsExport.Ignore
     val Service.isPixelFed: Boolean
         get() = ("pixelfed" == type.lowercase())
 
@@ -26,6 +30,7 @@ object ServiceEx {
      * !! Mastodon compatibility account is always false.
      * !! Use SocialHub#getPleromaAuth to make account object.
      */
+    @JsExport.Ignore
     val Service.isPleroma: Boolean
         get() = ("pleroma" == type.lowercase())
 }

--- a/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/model/MastodonComment.kt
+++ b/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/model/MastodonComment.kt
@@ -9,11 +9,13 @@ import work.socialhub.planetlink.model.Poll
 import work.socialhub.planetlink.model.Reaction
 import work.socialhub.planetlink.model.Service
 import work.socialhub.planetlink.model.common.AttributedString
+import kotlin.js.JsExport
 
 /**
  * Mastodon Comment Model
  * Mastodon のコメント情報
  */
+@JsExport
 class MastodonComment(
     service: Service
 ) : MicroBlogComment(service) {

--- a/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/model/MastodonPaging.kt
+++ b/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/model/MastodonPaging.kt
@@ -2,11 +2,13 @@ package work.socialhub.planetlink.mastodon.model
 
 import work.socialhub.planetlink.model.Identify
 import work.socialhub.planetlink.model.Paging
+import kotlin.js.JsExport
 
 /**
  * Mastodon Paging
  * Mastodon の特殊ページングに対応
  */
+@JsExport
 class MastodonPaging : Paging() {
 
     var minId: String? = null

--- a/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/model/MastodonPoll.kt
+++ b/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/model/MastodonPoll.kt
@@ -3,7 +3,9 @@ package work.socialhub.planetlink.mastodon.model
 import work.socialhub.planetlink.model.Emoji
 import work.socialhub.planetlink.model.Poll
 import work.socialhub.planetlink.model.Service
+import kotlin.js.JsExport
 
+@JsExport
 class MastodonPoll(
     service: Service
 ) : Poll(service) {

--- a/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/model/MastodonStream.kt
+++ b/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/model/MastodonStream.kt
@@ -2,7 +2,9 @@ package work.socialhub.planetlink.mastodon.model
 
 import work.socialhub.kmastodon.stream.api.EventStream
 import work.socialhub.planetlink.model.Stream
+import kotlin.js.JsExport
 
+@JsExport
 class MastodonStream(
     val stream: EventStream
 ) : Stream {

--- a/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/model/MastodonThread.kt
+++ b/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/model/MastodonThread.kt
@@ -3,7 +3,9 @@ package work.socialhub.planetlink.mastodon.model
 import work.socialhub.planetlink.model.Comment
 import work.socialhub.planetlink.model.Service
 import work.socialhub.planetlink.model.Thread
+import kotlin.js.JsExport
 
+@JsExport
 class MastodonThread(
     service: Service
 ) : Thread(service) {

--- a/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/model/MastodonUser.kt
+++ b/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/model/MastodonUser.kt
@@ -7,11 +7,13 @@ import work.socialhub.planetlink.model.Service
 import work.socialhub.planetlink.model.common.AttributedFiled
 import work.socialhub.planetlink.model.common.AttributedString
 import work.socialhub.planetlink.model.request.CommentForm
+import kotlin.js.JsExport
 
 /**
  * Mastodon User Model
  * Mastodon のユーザー情報
  */
+@JsExport
 class MastodonUser(
     service: Service
 ) : MicroBlogUser(service) {

--- a/matrix/src/commonMain/kotlin/work/socialhub/planetlink/matrix/expand/PlanetLinkEx.kt
+++ b/matrix/src/commonMain/kotlin/work/socialhub/planetlink/matrix/expand/PlanetLinkEx.kt
@@ -2,7 +2,9 @@ package work.socialhub.planetlink.matrix.expand
 
 import work.socialhub.planetlink.PlanetLink
 import work.socialhub.planetlink.matrix.action.MatrixAuth
+import kotlin.js.JsExport
 
+@JsExport
 object PlanetLinkEx {
 
     fun PlanetLink.Companion.matrix(

--- a/matrix/src/commonMain/kotlin/work/socialhub/planetlink/matrix/model/MatrixComment.kt
+++ b/matrix/src/commonMain/kotlin/work/socialhub/planetlink/matrix/model/MatrixComment.kt
@@ -5,7 +5,9 @@ import work.socialhub.planetlink.model.ID
 import work.socialhub.planetlink.model.Reaction
 import work.socialhub.planetlink.model.Service
 import work.socialhub.planetlink.model.request.CommentForm
+import kotlin.js.JsExport
 
+@JsExport
 class MatrixComment(
     service: Service
 ) : Comment(service) {

--- a/matrix/src/commonMain/kotlin/work/socialhub/planetlink/matrix/model/MatrixPaging.kt
+++ b/matrix/src/commonMain/kotlin/work/socialhub/planetlink/matrix/model/MatrixPaging.kt
@@ -1,7 +1,9 @@
 package work.socialhub.planetlink.matrix.model
 
 import work.socialhub.planetlink.model.Paging
+import kotlin.js.JsExport
 
+@JsExport
 class MatrixPaging : Paging() {
 
     var from: String? = null

--- a/matrix/src/commonMain/kotlin/work/socialhub/planetlink/matrix/model/MatrixUser.kt
+++ b/matrix/src/commonMain/kotlin/work/socialhub/planetlink/matrix/model/MatrixUser.kt
@@ -4,7 +4,9 @@ import work.socialhub.planetlink.model.ID
 import work.socialhub.planetlink.model.Service
 import work.socialhub.planetlink.model.User
 import work.socialhub.planetlink.model.request.CommentForm
+import kotlin.js.JsExport
 
+@JsExport
 class MatrixUser(
     service: Service
 ) : User(service) {

--- a/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/define/MisskeyActionType.kt
+++ b/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/define/MisskeyActionType.kt
@@ -1,7 +1,9 @@
 package work.socialhub.planetlink.misskey.define
 
 import work.socialhub.planetlink.define.action.ActionType
+import kotlin.js.JsExport
 
+@JsExport
 enum class MisskeyActionType : ActionType {
 
     // TimeLine

--- a/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/define/MisskeyFormKey.kt
+++ b/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/define/MisskeyFormKey.kt
@@ -1,5 +1,8 @@
 package work.socialhub.planetlink.misskey.define
 
+import kotlin.js.JsExport
+
+@JsExport
 object MisskeyFormKey {
 
     /** Renote の場合  */

--- a/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/define/MisskeyInstance.kt
+++ b/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/define/MisskeyInstance.kt
@@ -1,9 +1,12 @@
 package work.socialhub.planetlink.misskey.define
 
+import kotlin.js.JsExport
+
 /**
  * Famous Misskey Instances in Japan
  * 有名 Misskey インスタンスプリセット
  */
+@JsExport
 object MisskeyInstance {
 
     /** Misskey io  */

--- a/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/define/MisskeyNotificationType.kt
+++ b/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/define/MisskeyNotificationType.kt
@@ -2,8 +2,10 @@ package work.socialhub.planetlink.misskey.define
 
 import work.socialhub.kmisskey.entity.constant.NotificationType
 import work.socialhub.planetlink.define.NotificationActionType
+import kotlin.js.JsExport
 
 
+@JsExport
 enum class MisskeyNotificationType(
     val action: NotificationActionType?,
     val code: String

--- a/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/define/MisskeyReactionType.kt
+++ b/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/define/MisskeyReactionType.kt
@@ -1,5 +1,8 @@
 package work.socialhub.planetlink.misskey.define
 
+import kotlin.js.JsExport
+
+@JsExport
 enum class MisskeyReactionType(
     vararg val codes: String
 ) {

--- a/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/define/MisskeyScope.kt
+++ b/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/define/MisskeyScope.kt
@@ -1,7 +1,9 @@
 package work.socialhub.planetlink.misskey.define
 
 import work.socialhub.kmisskey.entity.constant.Scope
+import kotlin.js.JsExport
 
+@JsExport
 object MisskeyScope {
 
     /**

--- a/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/define/MisskeyVisibility.kt
+++ b/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/define/MisskeyVisibility.kt
@@ -1,5 +1,8 @@
 package work.socialhub.planetlink.misskey.define
 
+import kotlin.js.JsExport
+
+@JsExport
 enum class MisskeyVisibility(
     val code: String
 ) {

--- a/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/expand/PlanetLinkEx.kt
+++ b/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/expand/PlanetLinkEx.kt
@@ -2,7 +2,9 @@ package work.socialhub.planetlink.misskey.expand
 
 import work.socialhub.planetlink.PlanetLink
 import work.socialhub.planetlink.misskey.action.MisskeyAuth
+import kotlin.js.JsExport
 
+@JsExport
 object PlanetLinkEx {
 
     /**

--- a/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/expand/ServiceEx.kt
+++ b/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/expand/ServiceEx.kt
@@ -1,10 +1,13 @@
 package work.socialhub.planetlink.misskey.expand
 
 import work.socialhub.planetlink.model.Service
+import kotlin.js.JsExport
 
+@JsExport
 object ServiceEx {
 
     /** Is Misskey Account ?  */
+    @JsExport.Ignore
     val Service.isMisskey: Boolean
         get() = ("misskey" == type.lowercase())
 }

--- a/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/model/MisskeyComment.kt
+++ b/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/model/MisskeyComment.kt
@@ -8,11 +8,13 @@ import work.socialhub.planetlink.model.Reaction
 import work.socialhub.planetlink.model.Service
 import work.socialhub.planetlink.model.common.AttributedString
 import work.socialhub.planetlink.model.request.CommentForm
+import kotlin.js.JsExport
 
 /**
  * Misskey Comment Model
  * Misskey のコメントモデル
  */
+@JsExport
 class MisskeyComment(
     service: Service
 ) : MicroBlogComment(service) {

--- a/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/model/MisskeyNotification.kt
+++ b/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/model/MisskeyNotification.kt
@@ -2,7 +2,9 @@ package work.socialhub.planetlink.misskey.model
 
 import work.socialhub.planetlink.model.Notification
 import work.socialhub.planetlink.model.Service
+import kotlin.js.JsExport
 
+@JsExport
 class MisskeyNotification(
     service: Service
 ) : Notification(service) {

--- a/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/model/MisskeyPaging.kt
+++ b/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/model/MisskeyPaging.kt
@@ -2,11 +2,13 @@ package work.socialhub.planetlink.misskey.model
 
 import work.socialhub.planetlink.model.Identify
 import work.socialhub.planetlink.model.Paging
+import kotlin.js.JsExport
 
 /**
  * Misskey Paging
  * Misskey の特殊ページングに対応
  */
+@JsExport
 class MisskeyPaging : Paging() {
 
     var untilId: String? = null

--- a/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/model/MisskeyPoll.kt
+++ b/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/model/MisskeyPoll.kt
@@ -2,7 +2,9 @@ package work.socialhub.planetlink.misskey.model
 
 import work.socialhub.planetlink.model.Poll
 import work.socialhub.planetlink.model.Service
+import kotlin.js.JsExport
 
+@JsExport
 class MisskeyPoll(
     service: Service
 ) : Poll(service) {

--- a/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/model/MisskeyStream.kt
+++ b/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/model/MisskeyStream.kt
@@ -2,7 +2,9 @@ package work.socialhub.planetlink.misskey.model
 
 import work.socialhub.planetlink.model.Stream
 import work.socialhub.kmisskey.stream.MisskeyStream as MMisskeyStream
+import kotlin.js.JsExport
 
+@JsExport
 class MisskeyStream(
     val stream: MMisskeyStream
 ) : Stream {

--- a/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/model/MisskeyThread.kt
+++ b/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/model/MisskeyThread.kt
@@ -2,7 +2,9 @@ package work.socialhub.planetlink.misskey.model
 
 import work.socialhub.planetlink.model.Service
 import work.socialhub.planetlink.model.Thread
+import kotlin.js.JsExport
 
+@JsExport
 class MisskeyThread(
     service: Service
 ) : Thread(service) {

--- a/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/model/MisskeyUser.kt
+++ b/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/model/MisskeyUser.kt
@@ -7,11 +7,13 @@ import work.socialhub.planetlink.model.Service
 import work.socialhub.planetlink.model.common.AttributedFiled
 import work.socialhub.planetlink.model.common.AttributedString
 import work.socialhub.planetlink.model.support.Color
+import kotlin.js.JsExport
 
 /**
  * Misskey User
  * Misskey のユーザー情報
  */
+@JsExport
 class MisskeyUser(
     service: Service
 ) : MicroBlogUser(service) {

--- a/nostr/src/commonMain/kotlin/work/socialhub/planetlink/nostr/expand/PlanetLinkEx.kt
+++ b/nostr/src/commonMain/kotlin/work/socialhub/planetlink/nostr/expand/PlanetLinkEx.kt
@@ -2,7 +2,9 @@ package work.socialhub.planetlink.nostr.expand
 
 import work.socialhub.planetlink.PlanetLink
 import work.socialhub.planetlink.nostr.action.NostrAuth
+import kotlin.js.JsExport
 
+@JsExport
 object PlanetLinkEx {
 
     fun PlanetLink.Companion.nostr(

--- a/nostr/src/commonMain/kotlin/work/socialhub/planetlink/nostr/model/NostrComment.kt
+++ b/nostr/src/commonMain/kotlin/work/socialhub/planetlink/nostr/model/NostrComment.kt
@@ -5,7 +5,9 @@ import work.socialhub.planetlink.model.ID
 import work.socialhub.planetlink.model.Reaction
 import work.socialhub.planetlink.model.Service
 import work.socialhub.planetlink.model.request.CommentForm
+import kotlin.js.JsExport
 
+@JsExport
 class NostrComment(
     service: Service
 ) : Comment(service) {

--- a/nostr/src/commonMain/kotlin/work/socialhub/planetlink/nostr/model/NostrPaging.kt
+++ b/nostr/src/commonMain/kotlin/work/socialhub/planetlink/nostr/model/NostrPaging.kt
@@ -1,7 +1,9 @@
 package work.socialhub.planetlink.nostr.model
 
 import work.socialhub.planetlink.model.Paging
+import kotlin.js.JsExport
 
+@JsExport
 class NostrPaging : Paging() {
 
     var since: Long? = null

--- a/nostr/src/commonMain/kotlin/work/socialhub/planetlink/nostr/model/NostrUser.kt
+++ b/nostr/src/commonMain/kotlin/work/socialhub/planetlink/nostr/model/NostrUser.kt
@@ -6,7 +6,9 @@ import work.socialhub.planetlink.model.User
 import work.socialhub.planetlink.model.common.AttributedFiled
 import work.socialhub.planetlink.model.common.AttributedString
 import work.socialhub.planetlink.model.request.CommentForm
+import kotlin.js.JsExport
 
+@JsExport
 class NostrUser(
     service: Service
 ) : User(service) {

--- a/slack/src/commonMain/kotlin/work/socialhub/planetlink/slack/expand/PlanetLinkEx.kt
+++ b/slack/src/commonMain/kotlin/work/socialhub/planetlink/slack/expand/PlanetLinkEx.kt
@@ -2,7 +2,9 @@ package work.socialhub.planetlink.slack.expand
 
 import work.socialhub.planetlink.PlanetLink
 import work.socialhub.planetlink.slack.action.SlackAuth
+import kotlin.js.JsExport
 
+@JsExport
 object PlanetLinkEx {
 
     fun PlanetLink.Companion.slack(

--- a/slack/src/commonMain/kotlin/work/socialhub/planetlink/slack/expand/ServiceEx.kt
+++ b/slack/src/commonMain/kotlin/work/socialhub/planetlink/slack/expand/ServiceEx.kt
@@ -1,9 +1,12 @@
 package work.socialhub.planetlink.slack.expand
 
 import work.socialhub.planetlink.model.Service
+import kotlin.js.JsExport
 
+@JsExport
 object ServiceEx {
 
+    @JsExport.Ignore
     val Service.isSlack: Boolean
         get() = "slack" == type.lowercase()
 }

--- a/slack/src/commonMain/kotlin/work/socialhub/planetlink/slack/model/SlackChannel.kt
+++ b/slack/src/commonMain/kotlin/work/socialhub/planetlink/slack/model/SlackChannel.kt
@@ -2,7 +2,9 @@ package work.socialhub.planetlink.slack.model
 
 import work.socialhub.planetlink.model.Channel
 import work.socialhub.planetlink.model.Service
+import kotlin.js.JsExport
 
+@JsExport
 class SlackChannel(
     service: Service
 ) : Channel(service) {

--- a/slack/src/commonMain/kotlin/work/socialhub/planetlink/slack/model/SlackComment.kt
+++ b/slack/src/commonMain/kotlin/work/socialhub/planetlink/slack/model/SlackComment.kt
@@ -5,7 +5,9 @@ import work.socialhub.planetlink.model.ID
 import work.socialhub.planetlink.model.Reaction
 import work.socialhub.planetlink.model.Service
 import work.socialhub.planetlink.model.request.CommentForm
+import kotlin.js.JsExport
 
+@JsExport
 class SlackComment(
     service: Service
 ) : Comment(service) {

--- a/slack/src/commonMain/kotlin/work/socialhub/planetlink/slack/model/SlackIdentify.kt
+++ b/slack/src/commonMain/kotlin/work/socialhub/planetlink/slack/model/SlackIdentify.kt
@@ -2,7 +2,9 @@ package work.socialhub.planetlink.slack.model
 
 import work.socialhub.planetlink.model.Identify
 import work.socialhub.planetlink.model.Service
+import kotlin.js.JsExport
 
+@JsExport
 class SlackIdentify(
     service: Service
 ) : Identify(service) {

--- a/slack/src/commonMain/kotlin/work/socialhub/planetlink/slack/model/SlackMedia.kt
+++ b/slack/src/commonMain/kotlin/work/socialhub/planetlink/slack/model/SlackMedia.kt
@@ -1,6 +1,7 @@
 package work.socialhub.planetlink.slack.model
 
 import work.socialhub.planetlink.model.Media
+import kotlin.js.JsExport
 
 /**
  * Create a Media with Slack authorization header for private file access.

--- a/slack/src/commonMain/kotlin/work/socialhub/planetlink/slack/model/SlackPaging.kt
+++ b/slack/src/commonMain/kotlin/work/socialhub/planetlink/slack/model/SlackPaging.kt
@@ -1,7 +1,9 @@
 package work.socialhub.planetlink.slack.model
 
 import work.socialhub.planetlink.model.Paging
+import kotlin.js.JsExport
 
+@JsExport
 class SlackPaging : Paging() {
 
     var cursor: String? = null

--- a/slack/src/commonMain/kotlin/work/socialhub/planetlink/slack/model/SlackTeam.kt
+++ b/slack/src/commonMain/kotlin/work/socialhub/planetlink/slack/model/SlackTeam.kt
@@ -1,5 +1,8 @@
 package work.socialhub.planetlink.slack.model
 
+import kotlin.js.JsExport
+
+@JsExport
 data class SlackTeam(
     var id: String? = null,
     var name: String? = null,

--- a/slack/src/commonMain/kotlin/work/socialhub/planetlink/slack/model/SlackThread.kt
+++ b/slack/src/commonMain/kotlin/work/socialhub/planetlink/slack/model/SlackThread.kt
@@ -2,7 +2,9 @@ package work.socialhub.planetlink.slack.model
 
 import work.socialhub.planetlink.model.Service
 import work.socialhub.planetlink.model.Thread
+import kotlin.js.JsExport
 
+@JsExport
 class SlackThread(
     service: Service
 ) : Thread(service) {

--- a/slack/src/commonMain/kotlin/work/socialhub/planetlink/slack/model/SlackUser.kt
+++ b/slack/src/commonMain/kotlin/work/socialhub/planetlink/slack/model/SlackUser.kt
@@ -6,7 +6,9 @@ import work.socialhub.planetlink.model.User
 import work.socialhub.planetlink.model.common.AttributedFiled
 import work.socialhub.planetlink.model.common.AttributedString
 import work.socialhub.planetlink.model.request.CommentForm
+import kotlin.js.JsExport
 
+@JsExport
 class SlackUser(
     service: Service
 ) : User(service) {

--- a/tumblr/src/commonMain/kotlin/work/socialhub/planetlink/tumblr/define/TumblrIconSize.kt
+++ b/tumblr/src/commonMain/kotlin/work/socialhub/planetlink/tumblr/define/TumblrIconSize.kt
@@ -1,5 +1,8 @@
 package work.socialhub.planetlink.tumblr.define
 
+import kotlin.js.JsExport
+
+@JsExport
 enum class TumblrIconSize(
     val size: Int
 ) {

--- a/tumblr/src/commonMain/kotlin/work/socialhub/planetlink/tumblr/define/TumblrReactionType.kt
+++ b/tumblr/src/commonMain/kotlin/work/socialhub/planetlink/tumblr/define/TumblrReactionType.kt
@@ -1,9 +1,12 @@
 package work.socialhub.planetlink.tumblr.define
 
+import kotlin.js.JsExport
+
 /**
  * Tumblr Reaction Type
  * (Action code with alias)
  */
+@JsExport
 enum class TumblrReactionType(
     vararg val codes: String
 ) {

--- a/tumblr/src/commonMain/kotlin/work/socialhub/planetlink/tumblr/expand/AttributedStringEx.kt
+++ b/tumblr/src/commonMain/kotlin/work/socialhub/planetlink/tumblr/expand/AttributedStringEx.kt
@@ -8,7 +8,9 @@ import work.socialhub.planetlink.model.common.AttributedString
 import work.socialhub.planetlink.tumblr.expand.AttributedStringEx.StateType.ByClose
 import work.socialhub.planetlink.tumblr.expand.AttributedStringEx.StateType.ByOpen
 import work.socialhub.planetlink.tumblr.expand.AttributedStringEx.StateType.Init
+import kotlin.js.JsExport
 
+@JsExport
 object AttributedStringEx {
 
     enum class StateType {

--- a/tumblr/src/commonMain/kotlin/work/socialhub/planetlink/tumblr/expand/PlanetLinkEx.kt
+++ b/tumblr/src/commonMain/kotlin/work/socialhub/planetlink/tumblr/expand/PlanetLinkEx.kt
@@ -2,7 +2,9 @@ package work.socialhub.planetlink.tumblr.expand
 
 import work.socialhub.planetlink.PlanetLink
 import work.socialhub.planetlink.tumblr.action.TumblrAuth
+import kotlin.js.JsExport
 
+@JsExport
 object PlanetLinkEx {
 
     /**

--- a/tumblr/src/commonMain/kotlin/work/socialhub/planetlink/tumblr/model/TumblrComment.kt
+++ b/tumblr/src/commonMain/kotlin/work/socialhub/planetlink/tumblr/model/TumblrComment.kt
@@ -4,11 +4,13 @@ import work.socialhub.planetlink.define.ReactionType
 import work.socialhub.planetlink.model.Comment
 import work.socialhub.planetlink.model.Reaction
 import work.socialhub.planetlink.model.Service
+import kotlin.js.JsExport
 
 /**
  * Tumblr Comment Model
  * Tumblr のコメント情報
  */
+@JsExport
 class TumblrComment(
     service: Service
 ) : Comment(service) {

--- a/tumblr/src/commonMain/kotlin/work/socialhub/planetlink/tumblr/model/TumblrPaging.kt
+++ b/tumblr/src/commonMain/kotlin/work/socialhub/planetlink/tumblr/model/TumblrPaging.kt
@@ -2,11 +2,13 @@ package work.socialhub.planetlink.tumblr.model
 
 import work.socialhub.planetlink.model.Identify
 import work.socialhub.planetlink.model.Paging
+import kotlin.js.JsExport
 
 /**
  * Tumblr Paging
  * Tumblr の特殊ページング対応
  */
+@JsExport
 class TumblrPaging : Paging() {
 
     var sinceId: String? = null

--- a/tumblr/src/commonMain/kotlin/work/socialhub/planetlink/tumblr/model/TumblrUser.kt
+++ b/tumblr/src/commonMain/kotlin/work/socialhub/planetlink/tumblr/model/TumblrUser.kt
@@ -3,8 +3,10 @@ package work.socialhub.planetlink.tumblr.model
 import work.socialhub.planetlink.model.Relationship
 import work.socialhub.planetlink.model.Service
 import work.socialhub.planetlink.model.User
+import kotlin.js.JsExport
 
 
+@JsExport
 class TumblrUser(
     service: Service
 ) : User(service) {


### PR DESCRIPTION
- **feat(core): add @JsExport to model classes**
- **feat(core): add @JsExport to define and PlanetLink entry point**
- **feat(core): add @JsExport to action interfaces and callbacks**
- **feat(core): add @JsExport to model subpackages**
- **feat(core): add @JsExport to group model classes**
- **feat(all): add @JsExport to all module classes**
- **feat(adapters): add @JsExport to bluesky and misskey adapters**
- **feat(adapters): add @JsExport to remaining adapter modules**
