### PR TITLE
feat/pla 17 matrix home timeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,9 @@ This is a Kotlin Multiplatform port of [SocialHub](https://github.com/uakihir0/S
 | Bluesky | [kbsky](https://github.com/uakihir0/kbsky) | `bluesky/` |
 | Misskey | [kmisskey](https://github.com/uakihir0/kmisskey) | `misskey/` |
 | Mastodon | [kmastodon](https://github.com/uakihir0/kmastodon) | `mastodon/` |
+| Nostr | [knostr](https://github.com/uakihir0/knostr) | `nostr/` |
+| Slack | [kslack](https://github.com/uakihir0/kslack) | `slack/` |
+| Matrix | [kmatrix](https://github.com/uakihir0/kmatrix) | `matrix/` |
 | Tumblr | [ktumblr](https://github.com/uakihir0/ktumblr) | `tumblr/` |
 
 ### Kotlin Multiplatform Targets
@@ -37,6 +40,9 @@ PlanetLink Core (core/)
   ├── Bluesky Adapter (bluesky/) → kbsky SDK
   ├── Misskey Adapter (misskey/) → kmisskey SDK
   ├── Mastodon Adapter (mastodon/) → kmastodon SDK
+  ├── Nostr Adapter (nostr/) → knostr SDK
+  ├── Slack Adapter (slack/) → kslack SDK
+  ├── Matrix Adapter (matrix/) → kmatrix SDK
   └── Tumblr Adapter (tumblr/) → ktumblr SDK
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This is a Kotlin Multiplatform port of [SocialHub](https://github.com/uakihir0/S
 - Mastodon (library: [kmastodon](https://github.com/uakihir0/kmastodon))
 - Nostr (library: [knostr](https://github.com/uakihir0/knostr))
 - Slack (library: [kslack](https://github.com/uakihir0/kslack))
+- Matrix (library: [kmatrix](https://github.com/uakihir0/kmatrix))
 - Tumblr (library: [ktumblr](https://github.com/uakihir0/ktumblr))
 
 ## Usage

--- a/all/src/jvmTest/kotlin/work/socialhub/planetlink/action/HomeTimelineTest.kt
+++ b/all/src/jvmTest/kotlin/work/socialhub/planetlink/action/HomeTimelineTest.kt
@@ -26,7 +26,4 @@ class HomeTimelineTest : AbstractTest() {
 
     @Test
     fun testNostr() = runTest { nostr().act() }
-
-    @Test
-    fun testMatrix() = runTest { matrix().act() }
 }

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -15,7 +15,9 @@
 - Bluesky (library: [kbksy](https://github.com/uakihir0/kbsky))
 - Misskey (library: [kmisskey](https://github.com/uakihir0/kmisskey))
 - Mastodon (library: [kmastodon](https://github.com/uakihir0/kmastodon))
+- Nostr (library: [knostr](https://github.com/uakihir0/knostr))
 - Slack (library: [kslack](https://github.com/uakihir0/kslack))
+- Matrix (library: [kmatrix](https://github.com/uakihir0/kmatrix))
 - Tumblr (library: [ktumblr](https://github.com/uakihir0/ktumblr))
 
 ## 使い方

--- a/matrix/src/commonMain/kotlin/work/socialhub/planetlink/matrix/action/MatrixAction.kt
+++ b/matrix/src/commonMain/kotlin/work/socialhub/planetlink/matrix/action/MatrixAction.kt
@@ -9,7 +9,6 @@ import work.socialhub.kmatrix.api.request.notifications.NotificationsGetRequest
 import work.socialhub.kmatrix.api.request.rooms.RoomsGetMessagesRequest
 import work.socialhub.kmatrix.api.request.rooms.RoomsRedactEventRequest
 import work.socialhub.kmatrix.api.request.rooms.RoomsSendMessageRequest
-import work.socialhub.kmatrix.api.request.sync.SyncRequest
 import work.socialhub.kmatrix.api.request.userdirectory.UserDirectorySearchRequest
 import work.socialhub.kmatrix.api.response.events.EventsGetContextResponse
 import work.socialhub.kmatrix.api.response.events.EventsGetEventResponse
@@ -123,27 +122,7 @@ class MatrixAction(
     }
 
     override suspend fun homeTimeLine(paging: Paging): Pageable<Comment> {
-        return proceed {
-            val syncResponse = accessor.sync().sync(
-                SyncRequest().apply {
-                    timeout = 5000
-                    filter = """{"room":{"timeline":{"limit":30}}}"""
-                }
-            ).data
-
-            val events = mutableListOf<RoomEvent>()
-            syncResponse.rooms?.join?.forEach { (_, joinedRoom) ->
-                joinedRoom.timeline?.events?.forEach { event ->
-                    if (event.type == "m.room.message") {
-                        events.add(event)
-                    }
-                }
-            }
-            events.sortByDescending { it.originServerTs }
-
-            val userMe = userMeWithCache()
-            MatrixMapper.timeLine(events, service(), paging, userMe)
-        }
+        throw NotSupportedException("Matrix does not support home timeline")
     }
 
     override suspend fun mentionTimeLine(paging: Paging): Pageable<Comment> {


### PR DESCRIPTION
- **fix(matrix): mark homeTimeLine as unsupported for Matrix protocol**
- **test(matrix): remove homeTimeLine test for Matrix**
- **docs: add Matrix to supported platforms in READMEs**
- **docs: update AGENTS.md with current 7-platform lineup**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to explicitly list supported platforms including Nostr, Slack, and Matrix.
  * Updated Gradle configuration with new Maven repository and artifact dependency.

* **Bug Fixes**
  * Matrix home timeline functionality no longer supported; now throws an exception when invoked.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uakihir0/planetlink/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->