### PR TITLE
Fix review feedback on PR #64: relay concurrency and test timeout

### DIFF
--- a/all/src/jvmTest/kotlin/work/socialhub/planetlink/action/NostrRelayTest.kt
+++ b/all/src/jvmTest/kotlin/work/socialhub/planetlink/action/NostrRelayTest.kt
@@ -1,6 +1,7 @@
 package work.socialhub.planetlink.action
 
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import work.socialhub.planetlink.AbstractTest
 import work.socialhub.planetlink.PrintClass.dumpComments
 import work.socialhub.planetlink.model.Paging
@@ -16,12 +17,12 @@ class NostrRelayTest : AbstractTest() {
 
     @Test
     fun testNostrHomeTimeline() = runBlocking {
-        // nostr() creates account without relay connect (original bug scenario)
-        // ensureRelayConnected() in NostrAction should auto-connect
-        val account = nostr()
-        val result = account.action.homeTimeLine(Paging(20))
-        dumpComments(result)
-        println("Nostr homeTimeLine: ${result.entities.size} posts")
-        assertTrue(true, "homeTimeLine completed (auto-connect worked)")
+        withTimeout(30_000) {
+            val account = nostr()
+            val result = account.action.homeTimeLine(Paging(20))
+            dumpComments(result)
+            println("Nostr homeTimeLine: ${result.entities.size} posts")
+            assertTrue(true, "homeTimeLine completed (auto-connect worked)")
+        }
     }
 }

--- a/nostr/src/commonMain/kotlin/work/socialhub/planetlink/nostr/action/NostrAction.kt
+++ b/nostr/src/commonMain/kotlin/work/socialhub/planetlink/nostr/action/NostrAction.kt
@@ -29,7 +29,7 @@ import work.socialhub.planetlink.nostr.model.NostrPaging
 import work.socialhub.planetlink.nostr.model.NostrUser
 import kotlin.js.JsExport
 
-/** Nostr プラットフォームのアクション実装 */
+/** Action implementation for the Nostr platform */
 @JsExport
 class NostrAction(
     account: Account,
@@ -40,7 +40,6 @@ class NostrAction(
     private val social get() = accessor.social
     private val nostr get() = accessor.nostr
     private val pubkey get() = accessor.pubkey
-    @Volatile
     private var relayConnected = false
     private val relayMutex = kotlinx.coroutines.sync.Mutex()
 

--- a/nostr/src/commonMain/kotlin/work/socialhub/planetlink/nostr/action/NostrAction.kt
+++ b/nostr/src/commonMain/kotlin/work/socialhub/planetlink/nostr/action/NostrAction.kt
@@ -1,6 +1,7 @@
 package work.socialhub.planetlink.nostr.action
 
 import kotlin.time.Instant
+import kotlinx.coroutines.sync.withLock
 import work.socialhub.knostr.entity.Nip19Entity
 import work.socialhub.knostr.social.model.NostrDirectMessage
 import work.socialhub.knostr.social.model.NostrNote
@@ -39,12 +40,14 @@ class NostrAction(
     private val social get() = accessor.social
     private val nostr get() = accessor.nostr
     private val pubkey get() = accessor.pubkey
+    @Volatile
     private var relayConnected = false
+    private val relayMutex = kotlinx.coroutines.sync.Mutex()
 
     private suspend fun ensureRelayConnected() {
-        if (!relayConnected) {
-            // Launch relay connections in background (non-blocking)
-            // Using same pattern as knostr's AbstractTest.connectRelays()
+        if (relayConnected) return
+        relayMutex.withLock {
+            if (relayConnected) return
             val scope = kotlinx.coroutines.CoroutineScope(
                 kotlinx.coroutines.Dispatchers.Default + kotlinx.coroutines.SupervisorJob()
             )
@@ -54,7 +57,6 @@ class NostrAction(
             }
             nostr.relayPool().connectAll(scope)
 
-            // Wait for at least one relay to connect (max 5s)
             repeat(25) {
                 if (nostr.relays().getConnectedRelays().isNotEmpty()) {
                     relayConnected = true
@@ -62,7 +64,7 @@ class NostrAction(
                 }
                 kotlinx.coroutines.delay(200)
             }
-            relayConnected = true
+            throw SocialHubException("Failed to connect to any Nostr relay within 5 seconds")
         }
     }
 

--- a/nostr/src/commonMain/kotlin/work/socialhub/planetlink/nostr/action/NostrAuth.kt
+++ b/nostr/src/commonMain/kotlin/work/socialhub/planetlink/nostr/action/NostrAuth.kt
@@ -43,8 +43,9 @@ class NostrAuth(
     }
 
     /**
-     * Establish relay connections.
-     * Must be called after accountWithPrivateKey() before making any API calls.
+     * Explicitly establish relay connections.
+     * Optional: NostrAction auto-connects lazily on first API call.
+     * Call this if you want to pre-warm connections before making requests.
      */
     suspend fun connect() {
         val nostr = accessor.nostr

--- a/nostr/src/commonMain/kotlin/work/socialhub/planetlink/nostr/action/NostrAuth.kt
+++ b/nostr/src/commonMain/kotlin/work/socialhub/planetlink/nostr/action/NostrAuth.kt
@@ -10,7 +10,7 @@ import work.socialhub.planetlink.action.ServiceAuth
 import work.socialhub.planetlink.model.Account
 import work.socialhub.planetlink.model.Service
 
-/** Nostr の認証とアカウント生成を管理するクラス */
+/** Manages Nostr authentication and account creation */
 @JsExport
 class NostrAuth(
     var relays: List<String> = listOf(),
@@ -22,7 +22,7 @@ class NostrAuth(
     override val accessor: NostrAccessor
         get() = checkNotNull(_accessor) { "Nostr accessor is not initialized." }
 
-    /** 秘密鍵からアカウントを生成する */
+    /** Create an account from a private key (nsec) */
     fun accountWithPrivateKey(nsec: String? = null): Account {
         val key = nsec ?: this.nsec
             ?: throw IllegalArgumentException("nsec is required for accountWithPrivateKey")
@@ -68,7 +68,7 @@ class NostrAuth(
         }
     }
 
-    /** Nostr API へのアクセスに必要なオブジェクトを保持する */
+    /** Holds objects required for Nostr API access */
     class NostrAccessor(
         val nostr: Nostr,
         val social: NostrSocial,

--- a/nostr/src/commonMain/kotlin/work/socialhub/planetlink/nostr/action/NostrAuth.kt
+++ b/nostr/src/commonMain/kotlin/work/socialhub/planetlink/nostr/action/NostrAuth.kt
@@ -10,6 +10,7 @@ import work.socialhub.planetlink.action.ServiceAuth
 import work.socialhub.planetlink.model.Account
 import work.socialhub.planetlink.model.Service
 
+/** Nostr の認証とアカウント生成を管理するクラス */
 @JsExport
 class NostrAuth(
     var relays: List<String> = listOf(),
@@ -21,6 +22,7 @@ class NostrAuth(
     override val accessor: NostrAccessor
         get() = checkNotNull(_accessor) { "Nostr accessor is not initialized." }
 
+    /** 秘密鍵からアカウントを生成する */
     fun accountWithPrivateKey(nsec: String? = null): Account {
         val key = nsec ?: this.nsec
             ?: throw IllegalArgumentException("nsec is required for accountWithPrivateKey")
@@ -66,6 +68,7 @@ class NostrAuth(
         }
     }
 
+    /** Nostr API へのアクセスに必要なオブジェクトを保持する */
     class NostrAccessor(
         val nostr: Nostr,
         val social: NostrSocial,


### PR DESCRIPTION
- Add @Volatile and Mutex to ensureRelayConnected() for thread safety
- Throw exception on relay connection timeout instead of silently succeeding
- Add withTimeout(30s) to NostrRelayTest to prevent indefinite hanging
- Update NostrAuth.connect() KDoc to clarify auto-connect behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced relay connection initialization to ensure connections are properly established before proceeding; now throws an error if relay connection fails instead of silently continuing.

* **Documentation**
  * Updated connection method documentation to clarify relay connection pre-warming and lazy connection behavior.

* **Tests**
  * Added timeout handling to relay tests for improved reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uakihir0/planetlink/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->