### PR TITLE
fix: override userMeWithCache in NostrAction to fix JS generator bug

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/planetlink/action/AccountActionImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/planetlink/action/AccountActionImpl.kt
@@ -35,7 +35,7 @@ abstract class AccountActionImpl(
      * Get User me with cache.
      * キャッシュ付きで自分のユーザーを取得
      */
-    suspend fun userMeWithCache(): User {
+    open suspend fun userMeWithCache(): User {
         return me ?: run {
             userMe().also { me = it }
         }

--- a/nostr/src/commonMain/kotlin/work/socialhub/planetlink/nostr/action/NostrAction.kt
+++ b/nostr/src/commonMain/kotlin/work/socialhub/planetlink/nostr/action/NostrAction.kt
@@ -81,6 +81,20 @@ class NostrAction(
         }
     }
 
+    private suspend fun fetchUserMe(): User {
+        ensureRelayConnected()
+        return proceed {
+            val response = social.users().getProfile(pubkey)
+            val user = NostrMapper.user(response.data, service())
+            me = user
+            user
+        }
+    }
+
+    override suspend fun userMeWithCache(): User {
+        return me ?: fetchUserMe()
+    }
+
     override suspend fun user(id: Identify): User {
         val key = id.id!!.value<String>()
         if (key == pubkey && me != null) return me!!


### PR DESCRIPTION
KMP JS compiler generates a broken suspend bridge (c2m) in AccountActionImpl.userMeWithCache when calling userMe(). Subclasses that override userMe get a different mangled name (g2n), causing "yield* is not iterable" at runtime when the user cache is empty.

Fix by making userMeWithCache open and overriding it in NostrAction with a private fetchUserMe helper that avoids the broken bridge path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved user profile caching mechanism with enhanced relay connection validation for more reliable data fetching and retrieval.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uakihir0/planetlink/pull/69?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->