### PR TITLE
Fix/bluesky nullable display name

### DIFF
--- a/bluesky/src/commonMain/kotlin/work/socialhub/planetlink/bluesky/action/BlueskyMapper.kt
+++ b/bluesky/src/commonMain/kotlin/work/socialhub/planetlink/bluesky/action/BlueskyMapper.kt
@@ -66,7 +66,7 @@ object BlueskyMapper {
             isProtected = false
 
             id = ID(account.did)
-            name = account.displayName!!
+            name = account.displayName.orEmpty()
             screenName = account.handle
             iconImageUrl = account.avatar
             coverImageUrl = account.banner
@@ -93,7 +93,7 @@ object BlueskyMapper {
             isProtected = false
 
             id = ID(account.did)
-            name = account.displayName!!
+            name = account.displayName.orEmpty()
             screenName = account.handle
             iconImageUrl = account.avatar
 
@@ -115,7 +115,7 @@ object BlueskyMapper {
             isProtected = false
 
             id = ID(account.did)
-            name = account.displayName!!
+            name = account.displayName.orEmpty()
             screenName = account.handle
             iconImageUrl = account.avatar
 

--- a/bluesky/src/jvmTest/kotlin/work/socialhub/planetlink/bluesky/action/BlueskyMapperTest.kt
+++ b/bluesky/src/jvmTest/kotlin/work/socialhub/planetlink/bluesky/action/BlueskyMapperTest.kt
@@ -1,0 +1,61 @@
+package work.socialhub.planetlink.bluesky.action
+
+import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsProfileView
+import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsProfileViewBasic
+import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsProfileViewDetailed
+import work.socialhub.kbsky.model.app.bsky.feed.FeedDefsPostView
+import work.socialhub.kbsky.model.app.bsky.feed.FeedPost
+import work.socialhub.planetlink.model.Account
+import work.socialhub.planetlink.model.Service
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class BlueskyMapperTest {
+
+    private val service = Service("bluesky", Account())
+
+    @Test
+    fun userDetailed_nullDisplayName_fallbackToHandle() {
+        val account = ActorDefsProfileViewDetailed().apply {
+            did = "did:plc:test123"
+            handle = "xenobladerx98.bsky.social"
+            displayName = null
+        }
+
+        val user = BlueskyMapper.user(account, service)
+
+        assertEquals("xenobladerx98.bsky.social", user.name)
+    }
+
+    @Test
+    fun userDetailed_withDisplayName_usesDisplayName() {
+        val account = ActorDefsProfileViewDetailed().apply {
+            did = "did:plc:test456"
+            handle = "someone.bsky.social"
+            displayName = "Someone"
+        }
+
+        val user = BlueskyMapper.user(account, service)
+
+        assertEquals("Someone", user.name)
+    }
+
+    @Test
+    fun simpleComment_nullDisplayName_fallbackToHandle() {
+        val post = FeedDefsPostView().apply {
+            uri = "at://did:plc:test123/app.bsky.feed.post/abc"
+            cid = "bafytest"
+            author = ActorDefsProfileViewBasic(
+                did = "did:plc:test123",
+                handle = "xenobladerx98.bsky.social",
+                displayName = null,
+            )
+            indexedAt = "2025-01-01T00:00:00.000Z"
+            record = FeedPost().apply { text = "hello" }
+        }
+
+        val comment = BlueskyMapper.simpleComment(post, service)
+
+        assertEquals("xenobladerx98.bsky.social", comment.user!!.name)
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where missing user display information would cause the application to fail. User profiles now gracefully display the user handle as a fallback when the primary name information is unavailable.

* **Tests**
  * Added comprehensive test coverage for user profile mapping functionality to ensure the application handles missing name data reliably and consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->