### PR TITLE
Use account streamHost for MisskeyStream

### DIFF
--- a/bluesky/src/commonMain/kotlin/work/socialhub/planetlink/bluesky/action/BlueskyAction.kt
+++ b/bluesky/src/commonMain/kotlin/work/socialhub/planetlink/bluesky/action/BlueskyAction.kt
@@ -62,6 +62,7 @@ import work.socialhub.kbsky.util.ATUriParser
 import work.socialhub.kbsky.util.facet.FacetType
 import work.socialhub.kbsky.util.facet.FacetUtil
 import work.socialhub.planetlink.action.AccountActionImpl
+import work.socialhub.planetlink.action.RequestAction
 import work.socialhub.planetlink.bluesky.define.BlueskyReactionType
 import work.socialhub.planetlink.bluesky.model.BlueskyComment
 import work.socialhub.planetlink.bluesky.model.BlueskyPaging
@@ -1105,6 +1106,19 @@ class BlueskyAction(
         throw NotSupportedException()
     }
 
+    // ============================================================== //
+    // Request
+    // ============================================================== //
+    /**
+     * {@inheritDoc}
+     */
+    override fun request(): RequestAction {
+        return BlueskyRequest(account)
+    }
+
+    // ============================================================== //
+    // Stream
+    // ============================================================== //
     /**
      * {@inheritDoc}
      */

--- a/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/action/MisskeyAction.kt
+++ b/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/action/MisskeyAction.kt
@@ -1079,7 +1079,7 @@ class MisskeyAction(
     ): Stream {
         return proceed {
             val misskey = auth.accessor
-            val stream = MisskeyStream(misskey)
+            val stream = MisskeyStream(misskey, account.service.streamHost)
 
             val commentsListener = MisskeyCommentsListener(
                 callback,
@@ -1122,7 +1122,7 @@ class MisskeyAction(
     ): Stream {
         return proceed {
             val misskey = auth.accessor
-            val stream = MisskeyStream(misskey)
+            val stream = MisskeyStream(misskey, account.service.streamHost)
 
             val notificationListener = MisskeyNotificationListener(
                 callback,
@@ -1227,7 +1227,7 @@ class MisskeyAction(
     ): Stream {
         return proceed {
             val misskey = auth.accessor
-            val stream = MisskeyStream(misskey)
+            val stream = MisskeyStream(misskey, account.service.streamHost)
 
             val commentsListener = MisskeyCommentsListener(
                 callback,
@@ -1251,7 +1251,7 @@ class MisskeyAction(
     ): Stream {
         return proceed {
             val misskey = auth.accessor
-            val stream = MisskeyStream(misskey)
+            val stream = MisskeyStream(misskey, account.service.streamHost)
 
             val commentsListener = MisskeyCommentsListener(
                 callback,

--- a/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/action/MisskeyAction.kt
+++ b/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/action/MisskeyAction.kt
@@ -59,8 +59,10 @@ import work.socialhub.kmisskey.stream.callback.OpenedCallback
 import work.socialhub.kmisskey.stream.callback.RenoteCallback
 import work.socialhub.kmisskey.stream.callback.ReplayCallback
 import work.socialhub.kmisskey.stream.callback.TimelineCallback
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import work.socialhub.planetlink.action.AccountActionImpl
-import work.socialhub.planetlink.utils.toBlocking
 import work.socialhub.planetlink.action.RequestAction
 import work.socialhub.planetlink.action.callback.EventCallback
 import work.socialhub.planetlink.action.callback.comment.MentionCommentCallback
@@ -1088,7 +1090,7 @@ class MisskeyAction(
             )
 
             val connectionListener = MisskeyConnectionListener(callback) {
-                toBlocking { stream.homeTimeLine(commentsListener) }
+                stream.homeTimeLine(commentsListener)
             }
 
             setStreamConnectionCallback(stream, connectionListener)
@@ -1133,7 +1135,7 @@ class MisskeyAction(
             )
 
             val connectionListener = MisskeyConnectionListener(callback) {
-                toBlocking { stream.main(notificationListener) }
+                stream.main(notificationListener)
             }
 
             setStreamConnectionCallback(stream, connectionListener)
@@ -1236,7 +1238,7 @@ class MisskeyAction(
             )
 
             val connectionListener = MisskeyConnectionListener(callback) {
-                toBlocking { stream.localTimeline(commentsListener) }
+                stream.localTimeline(commentsListener)
             }
             setStreamConnectionCallback(stream, connectionListener)
             work.socialhub.planetlink.misskey.model.MisskeyStream(stream)
@@ -1259,7 +1261,7 @@ class MisskeyAction(
                 misskey.host,
             )
             val connectionListener = MisskeyConnectionListener(callback) {
-                toBlocking { stream.globalTimeline(commentsListener) }
+                stream.globalTimeline(commentsListener)
             }
 
             setStreamConnectionCallback(stream, connectionListener)
@@ -1372,7 +1374,7 @@ class MisskeyAction(
     // 通信に対してのコールバック設定
     internal class MisskeyConnectionListener(
         val listener: EventCallback,
-        val runnable: () -> Unit
+        val runnable: suspend () -> Unit
     ) : OpenedCallback,
         ClosedCallback,
         ErrorCallback {
@@ -1381,7 +1383,9 @@ class MisskeyAction(
             if (listener is ConnectCallback) {
                 listener.onConnect()
             }
-            runnable()
+            CoroutineScope(Dispatchers.Default).launch {
+                runnable()
+            }
         }
 
         override fun onClosed() {


### PR DESCRIPTION
Pass account.service.streamHost into MisskeyStream constructor in MisskeyAction (four stream creation sites). This ensures streaming connections use the account's configured stream host instead of the default, so listeners connect to the correct endpoint for the service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stream initialization to properly use configured host settings for timeline and notification streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->