### PR TITLE
fix: use local instance host for reaction and notification emoji URLs

### DIFF
--- a/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/action/MisskeyMapper.kt
+++ b/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/action/MisskeyMapper.kt
@@ -138,7 +138,7 @@ object MisskeyMapper {
             c.poll = poll(note, note.poll, service)
 
             // リアクションの設定
-            c.reactions = reactions(note.reactions, note.myReaction, noteUserHost)
+            c.reactions = reactions(note.reactions, note.myReaction, host)
 
             // リクエストホストを記録
             c.requesterHost = noteUserHost
@@ -241,7 +241,6 @@ object MisskeyMapper {
         host: String,
         service: Service,
     ): Notification {
-        val notifUserHost = notification.user?.host ?: host
         return MisskeyNotification(service).also { n ->
             val type = MisskeyNotificationType.of(notification.type)
 
@@ -263,7 +262,7 @@ object MisskeyMapper {
                     n.iconUrl == null
                 ) {
                     val code = reaction.replace(":", "")
-                    n.iconUrl = getEmojiURL(notifUserHost, code)
+                    n.iconUrl = getEmojiURL(host, code)
                 }
             }
 


### PR DESCRIPTION
Reaction emojis and notification emoji icons should always be resolved through the local instance's /emoji/ endpoint, which proxies remote emojis. Using the post author's or reactor's host was incorrect as it could point to a remote instance or proxy host.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed custom emoji and reaction URLs in Misskey integration to resolve against the correct server origin, ensuring proper display and functionality of custom reactions in notifications and comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->