### PR TITLE
fix: move stream logic into homeTimeLineStream to fix JS compilation

### DIFF
--- a/bluesky/src/commonMain/kotlin/work/socialhub/planetlink/bluesky/action/BlueskyAction.kt
+++ b/bluesky/src/commonMain/kotlin/work/socialhub/planetlink/bluesky/action/BlueskyAction.kt
@@ -1125,12 +1125,6 @@ class BlueskyAction(
     suspend fun homeTimeLineStream(
         callback: EventCallback
     ): Stream {
-        return setHomeTimeLineStream(callback)
-    }
-
-    override suspend fun setHomeTimeLineStream(
-        callback: EventCallback
-    ): Stream {
         return proceed {
             val followingDids = getAllFollowingDids() + did()
 
@@ -1183,6 +1177,12 @@ class BlueskyAction(
 
             BlueskyStream(client)
         }
+    }
+
+    override suspend fun setHomeTimeLineStream(
+        callback: EventCallback
+    ): Stream {
+        return homeTimeLineStream(callback)
     }
 
     /**


### PR DESCRIPTION
The KMP JS compiler fails to register the suspendBridge (f2q) on the prototype when a suspend fun only delegates to another suspend fun. By moving the proceed{} logic into homeTimeLineStream (matching the pattern used by Mastodon/Misskey), the compiler inlines the logic into a8p directly, avoiding the broken bridge reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal stream handling logic to improve code organization and maintainability. No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->