### PR TITLE
fix: resolve emoji URL returning localhost when host lacks scheme

### DIFF
--- a/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/action/MisskeyAction.kt
+++ b/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/action/MisskeyAction.kt
@@ -94,8 +94,10 @@ class MisskeyAction(
 
     /** Actual instance hostname for emoji URL construction */
     private val instanceHost: String
-        get() = account.service.host?.let { io.ktor.http.Url(it).host }
-            ?: io.ktor.http.Url(auth.host).host
+        get() = (account.service.host ?: auth.host)
+            .removePrefix("https://")
+            .removePrefix("http://")
+            .trimEnd('/')
 
     /** List of Emoji  */
     private var emojisCache: List<Emoji>? = null

--- a/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/action/MisskeyAction.kt
+++ b/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/action/MisskeyAction.kt
@@ -95,8 +95,12 @@ class MisskeyAction(
     /** Actual instance hostname for emoji URL construction */
     private val instanceHost: String
         get() = (account.service.host ?: auth.host)
+            .trim()
             .removePrefix("https://")
             .removePrefix("http://")
+            .substringBefore('/')
+            .substringBefore('?')
+            .substringBefore('#')
             .trimEnd('/')
 
     /** List of Emoji  */


### PR DESCRIPTION
Ktor's Url parser treats a bare hostname (e.g. "misskey.io") as a path segment and defaults host to "localhost". Replace Url parsing with simple prefix stripping to correctly extract the hostname.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized instance hostname detection to use direct string processing instead of URL parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->