### PR TITLE
fix: populate user profile info in stream events

### DIFF
--- a/bluesky/src/commonMain/kotlin/work/socialhub/planetlink/bluesky/action/BlueskyAction.kt
+++ b/bluesky/src/commonMain/kotlin/work/socialhub/planetlink/bluesky/action/BlueskyAction.kt
@@ -44,6 +44,7 @@ import work.socialhub.kbsky.stream.BlueskyStreamFactory
 import work.socialhub.kbsky.stream.api.entity.app.bsky.JetStreamSubscribeRequest
 import work.socialhub.kbsky.stream.entity.app.bsky.callback.JetStreamEventCallback
 import work.socialhub.kbsky.stream.entity.app.bsky.model.Event
+import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsProfileView
 import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsSavedFeedsPref
 import work.socialhub.kbsky.model.app.bsky.embed.EmbedImages
 import work.socialhub.kbsky.model.app.bsky.embed.EmbedImagesImage
@@ -1130,7 +1131,9 @@ class BlueskyAction(
         callback: EventCallback
     ): Stream {
         return proceed {
-            val followingDids = getAllFollowingDids() + did()
+            val profiles = getAllFollowingProfiles()
+            val profileCache = profiles.associateBy { it.did }
+            val followingDids = profiles.map { it.did } + did()
 
             val clients = followingDids
                 .chunked(MAX_WANTED_DIDS_PER_CONNECTION)
@@ -1151,7 +1154,7 @@ class BlueskyAction(
                                 val commit = event.commit ?: return
                                 if (commit.operation != "create") return
 
-                                val comment = Mapper.commentFromEvent(event, service())
+                                val comment = Mapper.commentFromEvent(event, service(), profileCache)
                                     ?: return
                                 callback.onUpdate(CommentEvent(comment))
                             }
@@ -1479,7 +1482,11 @@ class BlueskyAction(
      * フォロー中の全ユーザーの DID を取得
      */
     private suspend fun getAllFollowingDids(): List<String> {
-        val dids = mutableListOf<String>()
+        return getAllFollowingProfiles().map { it.did }
+    }
+
+    private suspend fun getAllFollowingProfiles(): List<ActorDefsProfileView> {
+        val profiles = mutableListOf<ActorDefsProfileView>()
         var cursor: String? = null
 
         do {
@@ -1490,11 +1497,14 @@ class BlueskyAction(
                     it.limit = 100
                 }
             )
-            dids.addAll(response.data.follows.map { it.did })
+            if (profiles.isEmpty()) {
+                profiles.add(response.data.subject)
+            }
+            profiles.addAll(response.data.follows)
             cursor = response.data.cursor
         } while (cursor != null)
 
-        return dids
+        return profiles
     }
 
     /**

--- a/bluesky/src/commonMain/kotlin/work/socialhub/planetlink/bluesky/action/BlueskyMapper.kt
+++ b/bluesky/src/commonMain/kotlin/work/socialhub/planetlink/bluesky/action/BlueskyMapper.kt
@@ -668,6 +668,7 @@ object BlueskyMapper {
     fun commentFromEvent(
         event: Event,
         service: Service,
+        profileCache: Map<String, ActorDefsProfileView> = emptyMap(),
     ): Comment? {
         val commit = event.commit ?: return null
         val record = commit.record?.asFeedPost ?: return null
@@ -678,10 +679,15 @@ object BlueskyMapper {
             id = ID(uri)
             cid = commit.cid
 
-            user = BlueskyUser(service).apply {
-                isSimple = true
-                isProtected = false
-                id = ID(event.did)
+            val profile = profileCache[event.did]
+            user = if (profile != null) {
+                user(profile, service)
+            } else {
+                BlueskyUser(service).apply {
+                    isSimple = true
+                    isProtected = false
+                    id = ID(event.did)
+                }
             }
 
             createAt = Instant.fromEpochSeconds(

--- a/bluesky/src/jvmTest/kotlin/work/socialhub/planetlink/bluesky/action/BlueskyStreamSplitPostTest.kt
+++ b/bluesky/src/jvmTest/kotlin/work/socialhub/planetlink/bluesky/action/BlueskyStreamSplitPostTest.kt
@@ -69,7 +69,9 @@ class BlueskyStreamSplitPostTest {
 
             println(">> received ${received.size} posts")
             received.forEach { c ->
-                println("  [${c.user?.id?.value<String>()}] ${c.text?.displayText?.take(80)}")
+                val user = c.user
+                println("  [${user?.accountIdentify}] ${user?.name} (icon=${user?.iconImageUrl != null})")
+                println("    ${c.text?.displayText?.take(80)}")
             }
 
             val myPost = received.find { it.text?.displayText?.contains("split stream verify") == true }


### PR DESCRIPTION
Jetstream events only contain DID, not user profile data. Cache following profiles at stream start and look up user info (name, handle, avatar) from cache when mapping events to comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced profile data handling for home timeline streaming with improved caching of followed account profiles

* **Tests**
  * Updated post reception logging to better capture account information and icon data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->