### PR TITLE
fix: use reactions API for Misskey like and inline commentWithCheck f…

### DIFF
--- a/bluesky/src/commonMain/kotlin/work/socialhub/planetlink/bluesky/action/BlueskyAction.kt
+++ b/bluesky/src/commonMain/kotlin/work/socialhub/planetlink/bluesky/action/BlueskyAction.kt
@@ -774,8 +774,16 @@ class BlueskyAction(
     private suspend fun commentWithCheck(
         id: Identify
     ): BlueskyComment {
-        return if (id is BlueskyComment) id
-        else comment(id) as BlueskyComment
+        if (id is BlueskyComment) return id
+        val posts = auth.accessor.feed().getPosts(
+            FeedGetPostsRequest(authProvider()).also {
+                it.uris = listOf(id.id!!.value())
+            }
+        )
+        return Mapper.simpleComment(
+            posts.data.posts[0],
+            service(),
+        ) as BlueskyComment
     }
 
     /**

--- a/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/action/MisskeyAction.kt
+++ b/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/action/MisskeyAction.kt
@@ -7,8 +7,6 @@ import work.socialhub.kmisskey.MisskeyException
 import work.socialhub.kmisskey.api.model.PollRequest
 import work.socialhub.kmisskey.api.request.blocks.BlocksCreateRequest
 import work.socialhub.kmisskey.api.request.blocks.BlocksDeleteRequest
-import work.socialhub.kmisskey.api.request.favorites.FavoritesCreateRequest
-import work.socialhub.kmisskey.api.request.favorites.FavoritesDeleteRequest
 import work.socialhub.kmisskey.api.request.files.FilesCreateRequest
 import work.socialhub.kmisskey.api.request.following.FollowingCreateRequest
 import work.socialhub.kmisskey.api.request.following.FollowingDeleteRequest
@@ -657,9 +655,10 @@ class MisskeyAction(
         id: Identify
     ) {
         proceedUnit {
-            auth.accessor.favorites().create(
-                FavoritesCreateRequest().also {
+            auth.accessor.reactions().create(
+                ReactionsCreateRequest().also {
                     it.noteId = id.id<String>()
+                    it.reaction = "❤"
                 })
         }
     }
@@ -671,8 +670,8 @@ class MisskeyAction(
         id: Identify
     ) {
         proceedUnit {
-            auth.accessor.favorites().delete(
-                FavoritesDeleteRequest().also {
+            auth.accessor.reactions().delete(
+                ReactionsDeleteRequest().also {
                     it.noteId = id.id<String>()
                 })
         }


### PR DESCRIPTION
…or Bluesky

Misskey's favorites API returns 403 PERMISSION_DENIED on newer instances. Replace likeComment/unlikeComment to use the reactions API with ❤ emoji instead, which is the standard way to "like" on Misskey.

For Bluesky, the commentWithCheck helper called comment(id) which relied on a virtual suspend bridge (w2n) that was not correctly resolved at runtime in the JS target, causing "yield* is not iterable" errors. Inline the getPosts call directly to avoid the broken bridge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal comment handling for the Bluesky platform.
  * Enhanced like and unlike interactions for the Misskey platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->