### PR TITLE
fix: avoid calling suspend functions inside proceed blocks for JS target

### DIFF
--- a/bluesky/src/commonMain/kotlin/work/socialhub/planetlink/bluesky/action/BlueskyAction.kt
+++ b/bluesky/src/commonMain/kotlin/work/socialhub/planetlink/bluesky/action/BlueskyAction.kt
@@ -270,8 +270,14 @@ class BlueskyAction(
             if (id is BlueskyUser) {
                 Mapper.relationship(id)
             } else {
-                val user = user(id) as BlueskyUser
-                Mapper.relationship(user)
+                // Fetch profile directly instead of calling user(id) to avoid
+                // broken virtual suspend bridge issue in KMP JS target
+                val response = auth.accessor.actor().getProfile(
+                    ActorGetProfileRequest(authProvider())
+                        .also { it.actor = id.id!!.value() }
+                )
+                val user = Mapper.user(response.data, service())
+                Mapper.relationship(user as BlueskyUser)
             }
         }
     }
@@ -722,11 +728,18 @@ class BlueskyAction(
                     if (req.quoteId != null) {
                         val uri = req.quoteId!!.value<String>()
 
-                        val id = Identify(service(), ID(uri))
-                        val comment = comment(id) as BlueskyComment
+                        // Fetch post directly to avoid broken virtual suspend bridge
+                        val quotePosts = auth.accessor.feed().getPosts(
+                            FeedGetPostsRequest(authProvider()).also {
+                                it.uris = listOf(uri)
+                            }
+                        )
+                        val quoteComment = Mapper.simpleComment(
+                            quotePosts.data.posts[0], service()
+                        ) as BlueskyComment
 
                         val record = EmbedRecord()
-                        record.record = RepoStrongRef(uri, comment.cid!!)
+                        record.record = RepoStrongRef(uri, quoteComment.cid!!)
 
                         // 既に画像が設定済みの場合
                         if (embedMedia != null) {
@@ -797,8 +810,15 @@ class BlueskyAction(
                 val did = response.data.did
                 val uri = "at://$did/app.bsky.feed.post/$rkey"
 
-                val identify = Identify(service(), ID(uri))
-                return@proceed comment(identify)
+                // Fetch post directly to avoid broken virtual suspend bridge
+                val posts = auth.accessor.feed().getPosts(
+                    FeedGetPostsRequest(authProvider()).also {
+                        it.uris = listOf(uri)
+                    }
+                )
+                return@proceed Mapper.simpleComment(
+                    posts.data.posts[0], service()
+                )
 
             } catch (e: Exception) {
                 throw handleException(e)

--- a/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/action/MastodonAction.kt
+++ b/mastodon/src/commonMain/kotlin/work/socialhub/planetlink/mastodon/action/MastodonAction.kt
@@ -157,29 +157,27 @@ class MastodonAction(
     override suspend fun user(
         url: String
     ): User {
-        return proceed {
-            var regex = "https://(.+?)/@(.+)".toRegex()
-            var matcher = regex.find(url)
+        var regex = "https://(.+?)/@(.+)".toRegex()
+        var matcher = regex.find(url)
+
+        if (matcher != null) {
+            val host = matcher.groupValues[1]
+            val screenName = matcher.groupValues[2]
+
+            val format: String = ("@$screenName@$host")
+            val users = searchUsers(format, Paging(10))
+            return users.entities.first { it.accountIdentify == format }
+
+        } else {
+            regex = "https://(.+?)/web/accounts/(.+)".toRegex()
+            matcher = regex.find(url)
 
             if (matcher != null) {
-                val host = matcher.groupValues[1]
-                val screenName = matcher.groupValues[2]
-
-                val format: String = ("@$screenName@$host")
-                val users = searchUsers(format, Paging(10))
-                users.entities.first { it.accountIdentify == format }
+                val id = matcher.groupValues[2]
+                return user(Identify(service(), ID(id)))
 
             } else {
-                regex = "https://(.+?)/web/accounts/(.+)".toRegex()
-                matcher = regex.find(url)
-
-                if (matcher != null) {
-                    val id = matcher.groupValues[2]
-                    user(Identify(service(), ID(id)))
-
-                } else {
-                    throw SocialHubException("this url is not supported format.")
-                }
+                throw SocialHubException("this url is not supported format.")
             }
         }
     }
@@ -707,29 +705,26 @@ class MastodonAction(
     override suspend fun comment(
         url: String
     ): Comment {
-        return proceed {
-            var regex = "https://(.+?)/@(.+?)/(.+)".toRegex()
-            var matcher = regex.find(url)
+        var regex = "https://(.+?)/@(.+?)/(.+)".toRegex()
+        var matcher = regex.find(url)
+
+        if (matcher != null) {
+            val id = matcher.groupValues[3]
+            val identify = Identify(service(), ID(id))
+            return comment(identify)
+
+        } else {
+            regex = "https://(.+?)/web/statuses/(.+)".toRegex()
+            matcher = regex.find(url)
 
             if (matcher != null) {
-                val id = matcher.groupValues[3]
+                val id = matcher.groupValues[2]
                 val identify = Identify(service(), ID(id))
-                comment(identify)
+                return comment(identify)
 
             } else {
-                regex = "https://(.+?)/web/statuses/(.+)".toRegex()
-                matcher = regex.find(url)
-
-                if (matcher != null) {
-                    val id = matcher.groupValues[2]
-                    val identify = Identify(service(), ID(id))
-                    comment(identify)
-
-                } else {
-                    throw SocialHubException("this url is not supported format.")
-                }
+                throw SocialHubException("this url is not supported format.")
             }
-
         }
     }
 

--- a/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/action/MisskeyAction.kt
+++ b/misskey/src/commonMain/kotlin/work/socialhub/planetlink/misskey/action/MisskeyAction.kt
@@ -168,26 +168,24 @@ class MisskeyAction(
     override suspend fun user(
         url: String
     ): User {
-        return proceed {
-            val regex = ("https://(.+?)/@(.+)").toRegex()
-            val matcher = regex.find(url)
+        val regex = ("https://(.+?)/@(.+)").toRegex()
+        val matcher = regex.find(url)
 
-            if (matcher != null) {
-                val host = matcher.groupValues[1]
-                val identify = matcher.groupValues[2]
+        if (matcher != null) {
+            val host = matcher.groupValues[1]
+            val identify = matcher.groupValues[2]
 
-                if (identify.contains("@")) {
-                    val format = ("@$identify")
-                    return@proceed user(Identify(service())
-                        .also { it.id = ID(format) })
-                } else {
-                    val format = ("@$identify@$host")
-                    return@proceed user(Identify(service())
-                        .also { it.id = ID(format) })
-                }
+            if (identify.contains("@")) {
+                val format = ("@$identify")
+                return user(Identify(service())
+                    .also { it.id = ID(format) })
+            } else {
+                val format = ("@$identify@$host")
+                return user(Identify(service())
+                    .also { it.id = ID(format) })
             }
-            throw SocialHubException("this url is not supported format.")
         }
+        throw SocialHubException("this url is not supported format.")
     }
 
     /**
@@ -635,19 +633,17 @@ class MisskeyAction(
     override suspend fun comment(
         url: String
     ): Comment {
-        return proceed {
-            val regex = ("https://(.+?)/notes/(.+)").toRegex()
-            val matcher = regex.find(url)
+        val regex = ("https://(.+?)/notes/(.+)").toRegex()
+        val matcher = regex.find(url)
 
-            if (matcher != null) {
-                return@proceed comment(
-                    Identify(service()).also {
-                        it.id = ID(matcher.groupValues[2])
-                    })
-            }
-
-            throw SocialHubException("this url is not supported format.")
+        if (matcher != null) {
+            return comment(
+                Identify(service()).also {
+                    it.id = ID(matcher.groupValues[2])
+                })
         }
+
+        throw SocialHubException("this url is not supported format.")
     }
 
     /**
@@ -1053,10 +1049,11 @@ class MisskeyAction(
     override suspend fun notification(
         paging: Paging
     ): Pageable<Notification> {
+        // Fetch emojis outside proceed to avoid broken virtual suspend bridge
+        val emojis = this.getEmojis()
+
         return proceed {
             val misskey = auth.accessor
-            // TODO: 並列でリクエストを実行
-            val emojis = this.getEmojis()
 
             val builder = INotificationsRequest()
             setPaging(builder, paging)

--- a/tumblr/src/commonMain/kotlin/work/socialhub/planetlink/tumblr/action/TumblrAction.kt
+++ b/tumblr/src/commonMain/kotlin/work/socialhub/planetlink/tumblr/action/TumblrAction.kt
@@ -146,10 +146,8 @@ class TumblrAction(
     override suspend fun user(
         url: String
     ): User {
-        return proceed {
-            val name = url.split("/").last()
-            user(Identify(service(), ID(name)))
-        }
+        val name = url.split("/").last()
+        return user(Identify(service(), ID(name)))
     }
 
     /**
@@ -228,19 +226,17 @@ class TumblrAction(
     override suspend fun relationship(
         id: Identify
     ): Relationship {
-        return proceed {
-            // オブジェクトに格納済みなので返却
-            if (id is TumblrUser) {
-                return@proceed id.relationship!!
-            }
-
-            // ユーザーの一部なのでそれを返却
-            val user = user(id)
-            if (user is TumblrUser) {
-                return@proceed user.relationship!!
-            }
-            throw IllegalStateException()
+        // オブジェクトに格納済みなので返却
+        if (id is TumblrUser) {
+            return id.relationship!!
         }
+
+        // ユーザーの一部なのでそれを返却
+        val user = user(id)
+        if (user is TumblrUser) {
+            return user.relationship!!
+        }
+        throw IllegalStateException()
     }
 
     // ============================================================== //


### PR DESCRIPTION
The KMP JS compiler generates generator-based coroutines where calling another suspend function from within a proceed {} lambda causes a "yield* is not iterable" error at runtime. This refactors all such call sites to either inline the API call directly or move the self-call outside the proceed block.

Affected: BlueskyAction, MastodonAction, MisskeyAction, TumblrAction