### PR TITLE
Pass shared ProfileCache to Nostr timeline and notification streams

### DIFF
--- a/nostr/src/commonMain/kotlin/work/socialhub/planetlink/nostr/action/NostrAction.kt
+++ b/nostr/src/commonMain/kotlin/work/socialhub/planetlink/nostr/action/NostrAction.kt
@@ -695,9 +695,10 @@ class NostrAction(
 
     override suspend fun setHomeTimeLineStream(callback: EventCallback): Stream {
         val userMe = userMeWithCache()
+        val cache = social.profileCache()
         val stream = NostrStream(
             accessor = accessor,
-            timelineStream = TimelineStream(nostr).also { ts ->
+            timelineStream = TimelineStream(nostr, cache).also { ts ->
                 ts.onNoteCallback = { note ->
                     if (callback is UpdateCommentCallback) {
                         val comment = NostrMapper.comment(note, service(), userMe)
@@ -712,9 +713,10 @@ class NostrAction(
 
     override suspend fun setNotificationStream(callback: EventCallback): Stream {
         val userMe = userMeWithCache()
+        val cache = social.profileCache()
         val stream = NostrStream(
             accessor = accessor,
-            notificationStream = NotificationStream(nostr).also { ns ->
+            notificationStream = NotificationStream(nostr, cache).also { ns ->
                 ns.onMentionCallback = { note ->
                     if (callback is MentionCommentCallback) {
                         val comment = NostrMapper.comment(note, service(), userMe)


### PR DESCRIPTION
Streams now receive the shared ProfileCache from NostrSocial so they can resolve author profiles from cache populated by feed/user queries instead of always issuing fresh relay requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized profile data handling in timeline and notification streams for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->