### PR TITLE
fix: clamp facet byte range to prevent IndexOutOfBoundsException

### DIFF
--- a/bluesky/src/commonMain/kotlin/work/socialhub/planetlink/bluesky/action/BlueskyMapper.kt
+++ b/bluesky/src/commonMain/kotlin/work/socialhub/planetlink/bluesky/action/BlueskyMapper.kt
@@ -52,6 +52,7 @@ import work.socialhub.planetlink.model.common.AttributedKind
 import work.socialhub.planetlink.model.common.AttributedString
 import work.socialhub.planetlink.utils.CollectionUtil.takeUntil
 import kotlin.math.max
+import kotlin.math.min
 
 object BlueskyMapper {
 
@@ -335,7 +336,7 @@ object BlueskyMapper {
 
                     // Facet の前を Text として取得
                     if (readIndex < index.byteStart!!) {
-                        val len: Int = (index.byteStart!! - readIndex)
+                        val len: Int = min((index.byteStart!! - readIndex), bytes.size)
                         val beforeBytes = bytes.copyOfRange(0, len)
 
                         // readIndex = index.byteStart!!
@@ -355,7 +356,7 @@ object BlueskyMapper {
                     }
 
                     // Facet の部分を切り出して作成
-                    val len = (index.byteEnd!! - index.byteStart!!)
+                    val len = min((index.byteEnd!! - index.byteStart!!), bytes.size)
                     val targetByte = bytes.copyOfRange(0, len)
 
                     readIndex = index.byteEnd!!


### PR DESCRIPTION
When a Bluesky post has facets whose byte range exceeds the actual text length (e.g. byteEnd=25 but remaining bytes=15), copyOfRange threw IndexOutOfBoundsException crashing the entire timeline parse.

Clamp len with min(facetLen, bytes.size) so malformed facets degrade gracefully instead of crashing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where text formatting in Bluesky posts could cause processing errors due to buffer limit handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->